### PR TITLE
Add drop_view method to migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec do
+task :default do
+  Rake::Task[:spec].execute
   `cd spec/dummy && rake db:drop db:create`
 end

--- a/lib/scenic/active_record/schema.rb
+++ b/lib/scenic/active_record/schema.rb
@@ -8,6 +8,10 @@ module Scenic
           execute "CREATE VIEW #{name} AS #{schema(name, version)};"
         end
 
+        def drop_view(name)
+          execute "DROP VIEW #{name};"
+        end
+
         private
 
         def schema(name, version)

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -9,29 +9,4 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
-
-  # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
-
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
-
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/scenic/active_record/schema_spec.rb
+++ b/spec/scenic/active_record/schema_spec.rb
@@ -7,24 +7,37 @@ end
 describe 'Scenic::ActiveRecord::Schema' do
   describe 'create_view' do
     it 'creates a view from a file' do
-      define_view :views, 1, "SELECT text 'Hello World' AS hello"
+      with_view_definition :views, 1, "SELECT text 'Hello World' AS hello" do
+        View.connection.create_view :views, 1
 
-      View.connection.create_view :views, 1
-
-      expect(View.all.pluck(:hello)).to eq ['Hello World']
-
-      remove_generated_files
+        expect(View.all.pluck(:hello)).to eq ['Hello World']
+      end
     end
   end
 
-  def define_view(name, version, schema)
-    @to_be_removed ||= []
-    view_file = ::Rails.root.join('db', 'views', "#{name}_v#{version}.sql")
-    @to_be_removed << view_file
-    File.open(view_file, 'w') { |f| f.write(schema) }
+  describe 'drop_view' do
+    it 'removes a view from the database' do
+      with_view_definition :things, 1, "SELECT text 'Hi' AS greeting" do
+        View.connection.create_view :things, 1
+
+        View.connection.drop_view :things
+
+        expect(views).not_to include 'things'
+      end
+    end
   end
 
-  def remove_generated_files
-    @to_be_removed.each { |f| File.delete(f) }
+  def views
+    ActiveRecord::Base.connection
+      .execute('SELECT table_name FROM INFORMATION_SCHEMA.views')
+      .map(&:values).flatten
+  end
+
+  def with_view_definition(name, version, schema)
+    view_file = ::Rails.root.join('db', 'views', "#{name}_v#{version}.sql")
+    File.open(view_file, 'w') { |f| f.write(schema) }
+    yield
+  ensure
+    File.delete view_file
   end
 end


### PR DESCRIPTION
It should take a view name and execute `DROP VIEW <name>`.
