### PR TITLE
Add database cleaner to fix spec failures

### DIFF
--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '>= 1.5'
+  spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pg'

--- a/spec/scenic/active_record/schema_spec.rb
+++ b/spec/scenic/active_record/schema_spec.rb
@@ -4,7 +4,7 @@ require 'scenic/active_record/schema'
 class View < ActiveRecord::Base
 end
 
-describe 'Scenic::ActiveRecord::Schema' do
+describe 'Scenic::ActiveRecord::Schema', :db do
   describe 'create_view' do
     it 'creates a view from a file' do
       with_view_definition :views, 1, "SELECT text 'Hello World' AS hello" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,14 @@
 ENV['RAILS_ENV'] = 'test'
 require 'active_record'
+require 'database_cleaner'
 require 'yaml'
-require File.expand_path("../dummy/config/environment", __FILE__)
+require File.expand_path('../dummy/config/environment', __FILE__)
+
+RSpec.configure do |config|
+  DatabaseCleaner.strategy = :transaction
+  config.around(:each, db: true) do |example|
+    DatabaseCleaner.start
+    example.run
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
After the first spec run, all subsequent runs were failing. Which is cool
because CI would never catch it.

Add DatabaseCleaner for :db specs (all of them currently) and have it use
transactions to prevent the failures.
