### PR TITLE
Use rspec 3

### DIFF
--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'pry'
 


### PR DESCRIPTION
With no gemfile.lock, the test suite would hapily use rspec 2. Let's keep
everyone at 3+.
