### PR TITLE
Make `pg` a runtime dependency

### DIFF
--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'pg'
 
   spec.add_dependency 'activerecord', '>= 4.0.0'
   spec.add_dependency 'railties', '>= 4.0.0'
+  spec.add_dependency 'pg'
 end


### PR DESCRIPTION
We have only a single adapter and it's required for the gem to function. When
we're ready for people to add additional adapter gems we can make this a
runtime dependency when the postgres adapter is required or something.
