### PR TITLE
Ensure view exists before updating

### DIFF
--- a/lib/scenic/active_record/schema.rb
+++ b/lib/scenic/active_record/schema.rb
@@ -13,7 +13,8 @@ module Scenic
         end
 
         def update_view(name, version)
-          execute "CREATE OR REPLACE VIEW #{name} AS #{schema(name, version)};"
+          drop_view(name)
+          create_view(name, version)
         end
 
         private

--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'pry'
 
   spec.add_dependency 'activerecord', '>= 4.0.0'
   spec.add_dependency 'railties', '>= 4.0.0'

--- a/spec/scenic/active_record/schema_spec.rb
+++ b/spec/scenic/active_record/schema_spec.rb
@@ -46,6 +46,13 @@ describe "Scenic::ActiveRecord::Schema", :db do
         end
       end
     end
+
+    it "raises an error if the view to be updated does not exist" do
+      with_view_definition :views, 2, "SELECT text 'Hi' as greeting" do
+        expect { View.connection.update_view :views, 2 }
+          .to raise_error(ActiveRecord::StatementInvalid, /does not exist/)
+      end
+    end
   end
 
   def views


### PR DESCRIPTION
View updating uses `CREATE OR UPDATE`, which means you could technically
update a view that does not yet exist. This is not likely to be desired, so we
detect this and raise an error.

Added pry to the test suite to aid in debugging.
