### PR TITLE
Stop resetting the database with rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,4 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default do
-  Rake::Task[:spec].execute
-  `cd spec/dummy && rake db:drop db:create`
-end
+task default: :spec


### PR DESCRIPTION
We're using DatabaseCleaner and transactions in our specs, so once the empty
database is created, each test run should be leaving it empty. This gets rid
of the delay which was happening after specs finished but before rake
completed.
