### PR TITLE
Make update_view reversible

### DIFF
--- a/lib/scenic/active_record/command_recorder/statement_arguments.rb
+++ b/lib/scenic/active_record/command_recorder/statement_arguments.rb
@@ -1,0 +1,44 @@
+module Scenic
+  module ActiveRecord
+    module CommandRecorder
+      class StatementArguments
+        def initialize(args)
+          @args = args.freeze
+        end
+
+        def view
+          @args[0]
+        end
+
+        def version
+          options[:version]
+        end
+
+        def revert_to_version
+          options[:revert_to_version]
+        end
+
+        def invert_version
+          StatementArguments.new([view, options_for_revert])
+        end
+
+        def to_a
+          @args.to_a
+        end
+
+        private
+
+        def options
+          @options ||= @args[1] || {}
+        end
+
+        def options_for_revert
+          options.clone.tap do |revert_options|
+            revert_options[:version] = revert_to_version
+            revert_options.delete(:revert_to_version)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/active_record/statements.rb
+++ b/lib/scenic/active_record/statements.rb
@@ -9,7 +9,7 @@ module Scenic
         execute "DROP VIEW #{name};"
       end
 
-      def update_view(name, version: nil)
+      def update_view(name, version: nil, revert_to_version: nil)
         if version.nil?
           raise ArgumentError, "version is required"
         end

--- a/spec/scenic/active_record/command_recorder/statement_arguments_spec.rb
+++ b/spec/scenic/active_record/command_recorder/statement_arguments_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+module Scenic::ActiveRecord::CommandRecorder
+  describe StatementArguments do
+    describe "#view" do
+      it "is the view name" do
+        raw_args = [:spaceships, { foo: :bar }]
+        args = StatementArguments.new(raw_args)
+
+        expect(args.view).to eq :spaceships
+      end
+    end
+
+    describe "#revert_to_version" do
+      it "is the revert_to_version from the keyword arguments" do
+        raw_args = [:spaceships, { revert_to_version: 42 }]
+        args = StatementArguments.new(raw_args)
+
+        expect(args.revert_to_version).to eq 42
+      end
+
+      it "is nil if the revert_to_version was not supplied" do
+        raw_args = [:spaceships, { foo: :bar }]
+        args = StatementArguments.new(raw_args)
+
+        expect(args.revert_to_version).to be nil
+      end
+    end
+
+    describe "#invert_version" do
+      it "returns object with version set to revert_to_version" do
+        raw_args = [:meatballs, { version: 42, revert_to_version: 15 }]
+
+        inverted_args = StatementArguments.new(raw_args).invert_version
+
+        expect(inverted_args.version).to eq 15
+        expect(inverted_args.revert_to_version).to be nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
For `update_view` to be reversible, it must be passed
`revert_to_version`.

This change extracts the nested `ScenicArguments` to a proper object
(`StatementArguments`) and _correctly_ inverts the version argument while
maintaining any other arguments that might have been passed.

This also corrects the inversion of drop_view to create the version specified
in `revert_to_version`.
