### PR TITLE
Extract database specific code to adapter

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -1,5 +1,6 @@
 require "scenic/version"
 require "scenic/railtie"
+require "scenic/adapters/postgres"
 require "scenic/active_record/command_recorder"
 require "scenic/active_record/schema_dumper"
 require "scenic/active_record/statements"
@@ -17,5 +18,9 @@ module Scenic
     ::ActiveRecord::SchemaDumper.class_eval do
       include Scenic::ActiveRecord::SchemaDumper
     end
+  end
+
+  def self.database
+    Scenic::Adapters::Postgres
   end
 end

--- a/lib/scenic/active_record/schema_dumper.rb
+++ b/lib/scenic/active_record/schema_dumper.rb
@@ -40,12 +40,10 @@ module Scenic
       end
 
       def views_with_definitions
-        @views_with_definitions ||=
-          Hash[@connection.execute(<<-SQL, 'SCHEMA').values]
-            SELECT viewname, definition
-            FROM pg_views
-            WHERE schemaname = ANY (current_schemas(false))
-          SQL
+        @views_with_definitions ||= begin
+          query = Scenic.database.views_with_definitions_query
+          Hash[@connection.execute(query, "SCHEMA").values]
+        end
       end
     end
   end

--- a/lib/scenic/active_record/statements.rb
+++ b/lib/scenic/active_record/statements.rb
@@ -11,11 +11,11 @@ module Scenic
 
         sql_definition ||= definition(name, version)
 
-        execute "CREATE VIEW #{name} AS #{sql_definition};"
+        execute Scenic.database.create_view(name, sql_definition)
       end
 
       def drop_view(name, revert_to_version: nil)
-        execute "DROP VIEW #{name};"
+        execute Scenic.database.drop_view(name)
       end
 
       def update_view(name, version: nil, revert_to_version: nil)

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -1,0 +1,21 @@
+module Scenic
+  module Adapters
+    module Postgres
+      def self.views_with_definitions_query
+        <<-SQL
+          SELECT viewname, definition
+          FROM pg_views
+          WHERE schemaname = ANY (current_schemas(false))
+        SQL
+      end
+
+      def self.create_view(name, sql_definition)
+        "CREATE VIEW #{name} AS #{sql_definition};"
+      end
+
+      def self.drop_view(name)
+        "DROP VIEW #{name};"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're only using Postgres now, so it's just hard-coded as the adapter, but
this should give us a very easy "in" for additional adapters.

With no changes, an adapter gem could theoretically override
`Scenic.database` to another object adhering to the interface and things would
"just work" :tm:.

Resolves #32
