### PR TITLE
Fix ammeter init

### DIFF
--- a/spec/support/generator_spec_setup.rb
+++ b/spec/support/generator_spec_setup.rb
@@ -1,5 +1,6 @@
 require "ammeter/rspec/generator/example.rb"
 require "ammeter/rspec/generator/matchers.rb"
+require "ammeter/init"
 
 RSpec.configure do |config|
   config.before(:example, :generator) do


### PR DESCRIPTION
Before requiring `ammeter/init`, running `rake spec` was failing because of
missing `dummy_development` and `dummy_test` databases, and missing references
to Ammeter modules. Adding this require statement made all specs pass on my
machine when running `bundle exec rake spec`.

Fixes #56, #57.
