### PR TITLE
Add support for CASCADE in drop_view and update_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Scenic detected that we already had an existing `search_results` view at version
 update to the version 2 schema. All that's left for you to do is tweak the
 schema in the new definition and run the `update_view` migration.
 
+If your view has dependent objects (e.g. other views) you can pass `cascade:
+true` to the `update_view` call to drop and recreate your view's children too:
+
+```ruby
+class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :search_results, version: 2, revert_to_version: 1, cascade: true
+  end
+end
+```
+
+If your view has any dependent _materialized_ views with indexes, those 
+indexes will be recreated too. If you have a complex heirarchy of materialized
+views with expensive calculations and large indexes this could take some time.
+
 ## What if I want to change a view without dropping it?
 
 The `update_view` statement used by default will drop your view then create
@@ -198,6 +213,14 @@ Scenic gives you `drop_view` too:
 ```ruby
 def change
   drop_view :search_results, revert_to_version: 2
+end
+```
+
+If your view has dependencies and you want Scenic to drop those too:
+
+```ruby
+def change
+  drop_view :search_results, revert_to_version: 2, cascade: true
 end
 ```
 

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -81,7 +81,7 @@ module Scenic
       def update_view(name, sql_definition, cascade=false)
         if cascade
           # Get existing views that could be dependent on this one.
-          existing_views = views.drop_while{|v| v.name != name}.drop(1)
+          existing_views = views.reject{|v| v.name == name}
 
           # Get indexes of existing materialized views 
           indexes = Indexes.new(connection: connection)

--- a/lib/scenic/adapters/postgres/index_reapplication.rb
+++ b/lib/scenic/adapters/postgres/index_reapplication.rb
@@ -35,10 +35,6 @@ module Scenic
           indexes.each(&method(:try_index_create))
         end
 
-        private
-
-        attr_reader :connection, :speaker
-
         def try_index_create(index)
           success = with_savepoint(index.index_name) do
             connection.execute(index.definition)
@@ -50,6 +46,10 @@ module Scenic
             say "index '#{index.index_name}' on '#{index.object_name}' is no longer valid and has been dropped."
           end
         end
+
+        private
+
+        attr_reader :connection, :speaker
 
         def with_savepoint(name)
           connection.execute("SAVEPOINT #{name}")

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -45,6 +45,11 @@ module Scenic
         raise ActiveRecord::IrreversibleMigration, message
       end
 
+      if method == :create_view && scenic_args.cascade
+        message = "#{method} is not reversible if dependent objects were also dropped with CASCADE"
+        raise ActiveRecord::IrreversibleMigration, message
+      end
+
       [method, scenic_args.invert_version.to_a]
     end
   end

--- a/lib/scenic/command_recorder/statement_arguments.rb
+++ b/lib/scenic/command_recorder/statement_arguments.rb
@@ -18,6 +18,10 @@ module Scenic
         options[:revert_to_version]
       end
 
+      def cascade
+        options[:cascade]
+      end
+
       def invert_version
         StatementArguments.new([view, options_for_revert])
       end

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -32,5 +32,11 @@ module Scenic
       @index_name = index_name
       @definition = definition
     end
+
+    def ==(index)
+      @object_name == index.object_name &&
+        @index_name = index.index_name &&
+        @definition == index.definition
+    end
   end
 end

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -50,16 +50,18 @@ module Scenic
     #   `version` argument to {#create_view}.
     # @param materialized [Boolean] Set to true if dropping a meterialized view.
     #   defaults to false.
+    # @param cascade [Boolean] Set to true if dependent objects should also be
+    #   dropped. defaults to false.
     # @return The database response from executing the drop statement.
     #
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    def drop_view(name, revert_to_version: nil, materialized: false, cascade: false)
       if materialized
-        Scenic.database.drop_materialized_view(name)
+        Scenic.database.drop_materialized_view(name, cascade)
       else
-        Scenic.database.drop_view(name)
+        Scenic.database.drop_view(name, cascade)
       end
     end
 
@@ -77,12 +79,14 @@ module Scenic
     #   `rake db rollback`
     # @param materialized [Boolean] True if updating a materialized view.
     #   Defaults to false.
+    # @param cascade [Boolean] Set to true if dependent objects should also be
+    #   dropped. defaults to false.
     # @return The database response from executing the create statement.
     #
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false, cascade: false)
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -100,9 +104,9 @@ module Scenic
       sql_definition ||= definition(name, version)
 
       if materialized
-        Scenic.database.update_materialized_view(name, sql_definition)
+        Scenic.database.update_materialized_view(name, sql_definition, cascade)
       else
-        Scenic.database.update_view(name, sql_definition)
+        Scenic.database.update_view(name, sql_definition, cascade)
       end
     end
 

--- a/spec/integration/cascade_spec.rb
+++ b/spec/integration/cascade_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe "Dropping a view and its dependencies with cascade", :db do
+  around do |example|
+    with_view_definition :greetings, 1, "SELECT text 'hola' as greeting" do
+      with_view_definition :dependent_greetings, 1, "SELECT * from greetings" do
+        example.run
+      end
+    end
+  end
+
+  it 'works' do
+    run_migration(migration_for_create, :up)
+    expect {
+      run_migration(migration_for_drop, :up)
+    }.to_not raise_error
+  end
+
+  describe 'as part of updating a view' do
+    around do |example|
+      with_view_definition :greetings, 2, "SELECT text 'good day' AS greeting" do
+        example.run
+      end
+    end
+
+    it 'recreates the dependent view' do
+      views = Scenic::Adapters::Postgres::Views.new(connection)
+      run_migration(migration_for_create, :up)
+      expect {
+        run_migration(migration_for_update, :up)
+      }.to_not change {
+        views.all.length
+      }
+    end
+
+    it 'recreates indexes on the dependent view' do
+      indexes = Scenic::Adapters::Postgres::Indexes.new(connection: connection)
+      run_migration(migration_for_create_materialized_dependent, :up)
+      run_migration(index_migration, :up)
+      expect {
+        run_migration(migration_for_update, :up)
+      }.to_not change {
+        indexes.on('dependent_greetings')
+      }
+    end
+
+    it 'reverts' do
+      run_migration(migration_for_create, :up)
+      run_migration(migration_for_update, :up)
+      run_migration(migration_for_update, :down)
+      greeting = execute("SELECT * FROM dependent_greetings")[0]["greeting"]
+      expect(greeting).to eq 'hola'
+    end
+  end
+
+  def migration_for_create
+    Class.new(migration_class) do
+      def change
+        create_view :greetings
+        create_view :dependent_greetings
+      end
+    end
+  end
+
+  def migration_for_create_materialized_dependent
+    Class.new(migration_class) do
+      def change
+        create_view :greetings
+        create_view :dependent_greetings, materialized: true
+      end
+    end
+  end
+
+  def migration_for_drop
+    Class.new(migration_class) do
+      def change
+        drop_view :greetings, revert_to_version: 1, cascade: true
+      end
+    end
+  end
+
+  def migration_for_update
+    Class.new(migration_class) do
+      def change
+        update_view :greetings, version: 2, revert_to_version: 1, cascade: true
+      end
+    end
+  end
+
+  def index_migration
+    Class.new(migration_class) do
+      def change
+        add_index :dependent_greetings, :greeting
+      end
+    end
+  end
+
+
+end

--- a/spec/integration/revert_spec.rb
+++ b/spec/integration/revert_spec.rb
@@ -52,23 +52,4 @@ describe "Reverting scenic schema statements", :db do
     end
   end
 
-  def migration_class
-    if Rails::VERSION::MAJOR >= 5
-      ::ActiveRecord::Migration[5.0]
-    else
-      ::ActiveRecord::Migration
-    end
-  end
-
-  def run_migration(migration, directions)
-    silence_stream(STDOUT) do
-      Array.wrap(directions).each do |direction|
-        migration.migrate(direction)
-      end
-    end
-  end
-
-  def execute(sql)
-    ActiveRecord::Base.connection.execute(sql)
-  end
 end

--- a/spec/scenic/command_recorder_spec.rb
+++ b/spec/scenic/command_recorder_spec.rb
@@ -37,6 +37,13 @@ describe Scenic::CommandRecorder do
       expect { recorder.revert { recorder.drop_view(*args) } }
         .to raise_error(ActiveRecord::IrreversibleMigration)
     end
+
+    it "raises when reverting with cascade set" do
+      args = [:users, { cascade: true, revert_to_version: 3 }]
+
+      expect { recorder.revert { recorder.drop_view(*args) } }
+        .to raise_error(ActiveRecord::IrreversibleMigration)
+    end
   end
 
   describe "#update_view" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -65,7 +65,7 @@ module Scenic
       it "removes a view from the database" do
         connection.drop_view :name
 
-        expect(Scenic.database).to have_received(:drop_view).with(:name)
+        expect(Scenic.database).to have_received(:drop_view).with(:name, false)
       end
     end
 
@@ -87,7 +87,7 @@ module Scenic
         connection.update_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, definition.to_sql)
+          .with(:name, definition.to_sql, false)
       end
 
       it "updates a view from a text definition" do
@@ -96,7 +96,7 @@ module Scenic
         connection.update_view(:name, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:update_view).
-          with(:name, sql_definition)
+          with(:name, sql_definition, false)
       end
 
       it "updates the materialized view in the database" do
@@ -108,7 +108,7 @@ module Scenic
         connection.update_view(:name, version: 3, materialized: true)
 
         expect(Scenic.database).to have_received(:update_materialized_view).
-          with(:name, definition.to_sql)
+          with(:name, definition.to_sql, false)
       end
 
       it "raises an error if not supplied a version or sql_defintion" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,12 @@ require "database_cleaner"
 require File.expand_path("../dummy/config/environment", __FILE__)
 require "support/generator_spec_setup"
 require "support/view_definition_helpers"
+require "support/migration_helpers"
 
 RSpec.configure do |config|
   config.order = "random"
   config.include ViewDefinitionHelpers
+  config.include MigrationHelpers
   DatabaseCleaner.strategy = :transaction
 
   config.around(:each, db: true) do |example|

--- a/spec/support/migration_helpers.rb
+++ b/spec/support/migration_helpers.rb
@@ -1,0 +1,27 @@
+module MigrationHelpers
+
+  def migration_class
+    if Rails::VERSION::MAJOR >= 5
+      ::ActiveRecord::Migration[5.0]
+    else
+      ::ActiveRecord::Migration
+    end
+  end
+
+  def run_migration(migration, directions)
+    silence_stream(STDOUT) do
+      Array.wrap(directions).each do |direction|
+        migration.migrate(direction)
+      end
+    end
+  end
+
+  def execute(sql)
+    connection.execute(sql)
+  end
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+
+end


### PR DESCRIPTION
@pixielabs <3 Scenic!

We use lots of materialized views with dependencies and it can be quite painful to update them in a migration, especially remembering to recreate indexes.

This PR:

1. Adds an optional `cascade: true` to `drop_view` and `update_view`.
2. Makes `update_view` recreate any views that are lost during the view being updated, including any indexes on those views.
3. Stops the user from rolling back `drop_view` if they use `cascade: true`, because you can't tell what might've been lost. I've made the necessary change in `CommandRecorder`.

Things of note / bits I'm unsure about:

1. I don't know how this impacts the sqlite adapter, if at all.
2. I made `try_index_create` public because I'm using it to recreate indexes, but I'm not using it via the `on()` method. This is a new use of `IndexReapplication` and I'm conscious of that; perhaps some bigger API changes could be done here, but I didn't want to mess around too much!

If there's anything that needs changing, or any questions, let me know!

**December 2020 update**: Phew, the years just fly by don't they. There's a [summary of outstanding known issues](https://github.com/scenic-views/scenic/pull/218#issuecomment-736713334) at the bottom of this thread.