### PR TITLE
Add method to return materialized view is populated or not

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -234,7 +234,8 @@ module Scenic
         # all relations other than some materialized views)
         # Doc: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
         # Test case: https://github.com/postgres/postgres/blob/master/src/test/regress/expected/matview.out
-        execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")&.first["relispopulated"].in? ["t", true]
+        relations = execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")
+        relations.length > 0 && relations.first["relispopulated"].in? ["t", true]
       end
 
       private

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -230,7 +230,8 @@ module Scenic
       def materialized_view_populated?(name)
         raise_unless_materialized_views_supported
 
-        # > relispopulated: True if relation is populated (this is true for all relations other than some materialized views)
+        # > relispopulated: True if relation is populated (this is true for
+        # all relations other than some materialized views)
         # Doc: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
         # Test case: https://github.com/postgres/postgres/blob/master/src/test/regress/expected/matview.out
         execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")&.first["relispopulated"].in? ["t", true]

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -233,7 +233,7 @@ module Scenic
         # > relispopulated: True if relation is populated (this is true for all relations other than some materialized views)
         # Doc: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
         # Test case: https://github.com/postgres/postgres/blob/master/src/test/regress/expected/matview.out
-        !!execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")&.first["relispopulated"]
+        execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")&.first["relispopulated"].in? ["t", true]
       end
 
       private

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -220,10 +220,26 @@ module Scenic
         end
       end
 
+      # Returns true if a materialized is populated.
+      #
+      # @param name The name of the materialized view
+      # @raise [MaterializedViewsNotSupportedError] if the version of Postgres
+      #   in use does not support materialized views.
+      #
+      # @return [boolean]
+      def materialized_view_populated?(name)
+        raise_unless_materialized_views_supported
+
+        # > relispopulated: True if relation is populated (this is true for all relations other than some materialized views)
+        # Doc: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
+        # Test case: https://github.com/postgres/postgres/blob/master/src/test/regress/expected/matview.out
+        !!execute("SELECT relispopulated FROM pg_class WHERE relname = '#{quote_string(name)}'")&.first["relispopulated"]
+      end
+
       private
 
       attr_reader :connectable
-      delegate :execute, :quote_table_name, to: :connection
+      delegate :execute, :quote_table_name, :quote_string, to: :connection
 
       def connection
         Connection.new(connectable.connection)


### PR DESCRIPTION
Added a method which return the view is populated or not.

`REFRESH MATERIALIZED VIEW CONCURRENTLY` doesn't work for a view which is not populated, even it has unique index. This method is useful to perform concurrent refresh if it's possible.

Real use case in Rails will be like this:

- Database is loaded from structure.sql to run specs, but the view isn't populated yet so concurrent refresh is not possible. We want to fallback to normal(non-concurrent) refresh in this case.
- After initial population, views are expected to be refreshed concurrently. It's possible because the view is already populated.

Our team is using a concern below to cope with the case. This pull request is extracted from this.

```
module MaterializedView
  extend ActiveSupport::Concern

  included do
    class << self
      def materialized_view_populated?
        connection.execute("SELECT relispopulated FROM pg_class WHERE relname = '#{table_name}'").first['relispopulated']
      end

      def refresh_materialized_view(concurrently = true)
        Scenic.database.refresh_materialized_view(table_name, concurrently: materialized_view_populated? && concurrently, cascade: false)
      end
    end
  end
end
```