### PR TITLE
Fix materialized view dependency handling with name substring

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,85 @@
-DotPosition:
-  EnforcedStyle: leading
+Metrics/ClassLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  CountComments: true  # count full line comments?
+  Max: 25
+  ExcludedMethods: []
+  Exclude:
+    - "spec/**/*"
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/LineLength:
+  Max: 80
+
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    find: find
+    inject: reduce
+    collect: map
+    find_all: select
+Style/FrozenStringLiteralComment:
+  Description: >-
+    Add the frozen_string_literal comment to the top of files
+    to help transition from Ruby 2.3.0 to Ruby 3.0.
+  Enabled: false
+Style/OneLineConditional:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  Enabled: true
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Layout/AlignParameters:
+  Enabled: false
+Layout/ConditionPosition:
+  Enabled: false
+Layout/DotPosition:
+  EnforcedStyle: leading
+Layout/ExtraSpacing:
+  Enabled: true
+Layout/MultilineOperationIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
+Lint/AmbiguousOperator:
+  Enabled: true
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+Lint/DuplicatedKey:
+  Enabled: true

--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -47,7 +47,7 @@ module Scenic
             dependency_hash = parse_to_hash(raw_dependencies)
             sorted_arr = tsort(dependency_hash)
             idx = sorted_arr.find_index do |dep|
-              if view_to_refresh.to_s.include?('.')
+              if view_to_refresh.to_s.include?(".")
                 dep == view_to_refresh.to_s
               else
                 dep.ends_with?(".#{view_to_refresh}")

--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -47,7 +47,7 @@ module Scenic
             dependency_hash = parse_to_hash(raw_dependencies)
             sorted_arr = tsort(dependency_hash)
             idx = sorted_arr.find_index do |dep|
-              dep.include?(view_to_refresh.to_s)
+              dep.ends_with?(view_to_refresh.to_s)
             end
             return [] if idx.nil?
             sorted_arr[0...idx]

--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -47,7 +47,11 @@ module Scenic
             dependency_hash = parse_to_hash(raw_dependencies)
             sorted_arr = tsort(dependency_hash)
             idx = sorted_arr.find_index do |dep|
-              dep.ends_with?(view_to_refresh.to_s)
+              if view_to_refresh.to_s.include?('.')
+                dep == view_to_refresh.to_s
+              else
+                dep.ends_with?(".#{view_to_refresh}")
+              end
             end
             return [] if idx.nil?
             sorted_arr[0...idx]

--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -53,8 +53,12 @@ module Scenic
                 dep.ends_with?(".#{view_to_refresh}")
               end
             end
-            return [] if idx.nil?
-            sorted_arr[0...idx]
+
+            if idx.present?
+              sorted_arr[0...idx]
+            else
+              []
+            end
           end
 
           private

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -5,7 +5,7 @@ module Scenic
     describe Postgres::RefreshDependencies, :db do
       let(:adapter) { Postgres.new }
 
-      context "when the view has dependencies" do
+      context "view has dependencies" do
         before do
           adapter.create_materialized_view(
             "first",
@@ -53,11 +53,11 @@ module Scenic
             with("public.more_fourth").ordered
         end
 
-        it "refreshes dependencies in the correct order when called without a namespace" do
+        it "refreshes in the correct order when called without a namespace" do
           described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
         end
 
-        it "refreshes dependencies in the correct order when called with a namespace" do
+        it "refreshes in the correct order when called with a namespace" do
           described_class.call(:'public.fourth', adapter, ActiveRecord::Base.connection)
         end
       end

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -5,7 +5,7 @@ module Scenic
     describe Postgres::RefreshDependencies, :db do
       let(:adapter) { Postgres.new }
 
-      context 'when the view has dependencies' do
+      context "when the view has dependencies" do
         before do
           adapter.create_materialized_view(
             "first",
@@ -53,20 +53,20 @@ module Scenic
             with("public.more_fourth").ordered
         end
 
-        it 'refreshes dependencies in the correct order when called without a namespace' do
+        it "refreshes dependencies in the correct order when called without a namespace" do
           described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
         end
 
-        it 'refreshes dependencies in the correct order when called with a namespace' do
+        it "refreshes dependencies in the correct order when called with a namespace" do
           described_class.call(:'public.fourth', adapter, ActiveRecord::Base.connection)
         end
       end
 
-      context 'when the view does not have dependencies' do
+      context "when the view does not have dependencies" do
         it "does not raise an error" do
           adapter.create_materialized_view(
-              "first",
-              "SELECT text 'hi' AS greeting",
+            "first",
+            "SELECT text 'hi' AS greeting",
           )
 
           expect {

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -22,8 +22,13 @@ module Scenic
         )
 
         adapter.create_materialized_view(
-          "fourth",
+          "fourth_staging",
           "SELECT * from third",
+        )
+
+        adapter.create_materialized_view(
+          "fourth",
+          "SELECT * from fourth_staging",
         )
 
         expect(adapter).to receive(:refresh_materialized_view).
@@ -34,6 +39,9 @@ module Scenic
 
         expect(adapter).to receive(:refresh_materialized_view).
           with("public.third").ordered
+
+        expect(adapter).to receive(:refresh_materialized_view).
+          with("public.fourth_staging").ordered
 
         described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
       end

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -3,60 +3,76 @@ require "spec_helper"
 module Scenic
   module Adapters
     describe Postgres::RefreshDependencies, :db do
-      it "refreshes dependecies in the correct order" do
-        adapter = Postgres.new
+      let(:adapter) { Postgres.new }
 
-        adapter.create_materialized_view(
-          "first",
-          "SELECT text 'hi' AS greeting",
-        )
+      context 'when the view has dependencies' do
+        before do
+          adapter.create_materialized_view(
+            "first",
+            "SELECT text 'hi' AS greeting",
+          )
 
-        adapter.create_materialized_view(
-          "second",
-          "SELECT * from first",
-        )
+          adapter.create_materialized_view(
+            "second",
+            "SELECT * from first",
+          )
 
-        adapter.create_materialized_view(
-          "third",
-          "SELECT * from first UNION SELECT * from second",
-        )
+          adapter.create_materialized_view(
+            "third",
+            "SELECT * from first UNION SELECT * from second",
+          )
 
-        adapter.create_materialized_view(
-          "fourth_staging",
-          "SELECT * from third",
-        )
+          adapter.create_materialized_view(
+            "fourth_staging",
+            "SELECT * from third",
+          )
 
-        adapter.create_materialized_view(
-          "fourth",
-          "SELECT * from fourth_staging",
-        )
+          adapter.create_materialized_view(
+            "more_fourth",
+            "SELECT * from fourth_staging",
+          )
 
-        expect(adapter).to receive(:refresh_materialized_view).
-          with("public.first").ordered
+          adapter.create_materialized_view(
+            "fourth",
+            "SELECT * from more_fourth UNION SELECT * from fourth_staging",
+          )
 
-        expect(adapter).to receive(:refresh_materialized_view).
-          with("public.second").ordered
+          expect(adapter).to receive(:refresh_materialized_view).
+            with("public.first").ordered
 
-        expect(adapter).to receive(:refresh_materialized_view).
-          with("public.third").ordered
+          expect(adapter).to receive(:refresh_materialized_view).
+            with("public.second").ordered
 
-        expect(adapter).to receive(:refresh_materialized_view).
-          with("public.fourth_staging").ordered
+          expect(adapter).to receive(:refresh_materialized_view).
+            with("public.third").ordered
 
-        described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
+          expect(adapter).to receive(:refresh_materialized_view).
+            with("public.fourth_staging").ordered
+
+          expect(adapter).to receive(:refresh_materialized_view).
+            with("public.more_fourth").ordered
+        end
+
+        it 'refreshes dependencies in the correct order when called without a namespace' do
+          described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
+        end
+
+        it 'refreshes dependencies in the correct order when called with a namespace' do
+          described_class.call(:'public.fourth', adapter, ActiveRecord::Base.connection)
+        end
       end
 
-      it "does not raise an error when a view has no materialized view dependencies" do
-        adapter = Postgres.new
+      context 'when the view does not have dependencies' do
+        it "does not raise an error" do
+          adapter.create_materialized_view(
+              "first",
+              "SELECT text 'hi' AS greeting",
+          )
 
-        adapter.create_materialized_view(
-          "first",
-          "SELECT text 'hi' AS greeting",
-        )
-
-        expect {
-          described_class.call(:first, adapter, ActiveRecord::Base.connection)
-        }.not_to raise_error
+          expect {
+            described_class.call(:first, adapter, ActiveRecord::Base.connection)
+          }.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
Addressing #258 - cascade failing to identify dependent views when the `view_to_refresh` is a substring of a dependency.

Took a guess at some of the desired behaviors wrt invoking the refresh method with or without the namespace.