### PR TITLE
Update uses of deprecated PG constants

### DIFF
--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -57,7 +57,15 @@ module Scenic
 
         def pg_identifier(name)
           return name if name =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/
-          PGconn.quote_ident(name)
+          pgconn.quote_ident(name)
+        end
+
+        def pgconn
+          if defined?(PG::Connection)
+            PG::Connection
+          else
+            PGconn
+          end
         end
       end
     end


### PR DESCRIPTION
`pg` 0.21 + has deprecated `PGConn` in favor of `PG::Connection`. This
change fixes the following deprecation:

> The PGconn, PGresult, and PGError constants are deprecated, and will
be removed as of version 1.0