### PR TITLE
Update travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ notifications:
     - false
 sudo: false
 rvm:
-  - 2.5.0
-  - 2.4.1
-  - 2.3.4
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 gemfile:
   - gemfiles/rails42.gemfile
   - gemfiles/rails50.gemfile
@@ -30,3 +31,8 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
+  exclude:
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails_edge.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -18,7 +18,9 @@ appraise "rails52" do
   gem "railties", "~> 5.2.0"
 end
 
-appraise "rails-edge" do
-  gem "rails", git: "https://github.com/rails/rails"
-  gem "arel", git: "https://github.com/rails/arel"
+if RUBY_VERSION >= "2.5.0"
+  appraise "rails-edge" do
+    gem "rails", git: "https://github.com/rails/rails"
+    gem "arel", git: "https://github.com/rails/arel"
+  end
 end


### PR DESCRIPTION
Ruby 2.6 is out, so I've added it to the matrix. Rails 6 (rails edge)
requires 2.5+ so we can skip building it with older rubies.