### PR TITLE
Fix dependency calculation with overlapping names

### DIFF
--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -48,7 +48,11 @@ module Scenic
             sorted_arr = tsort(dependency_hash)
 
             idx = sorted_arr.find_index do |dep|
-              dep.include?(view_to_refresh.to_s)
+              if view_to_refresh.to_s.include?(".")
+                dep == view_to_refresh.to_s
+              else
+                dep.ends_with?(".#{view_to_refresh}")
+              end
             end
 
             if idx.present?

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -3,52 +3,73 @@ require "spec_helper"
 module Scenic
   module Adapters
     describe Postgres::RefreshDependencies, :db do
-      it "refreshes dependecies in the correct order" do
-        adapter = Postgres.new
+      context "view has dependencies" do
+        let(:adapter) { Postgres.new }
 
-        adapter.create_materialized_view(
-          "first",
-          "SELECT text 'hi' AS greeting",
-        )
+        before do
+          adapter.create_materialized_view(
+            "first",
+            "SELECT text 'hi' AS greeting",
+          )
+          adapter.create_materialized_view(
+            "second",
+            "SELECT * FROM first",
+          )
+          adapter.create_materialized_view(
+            "third",
+            "SELECT * FROM first UNION SELECT * FROM second",
+          )
+          adapter.create_materialized_view(
+            "fourth_1",
+            "SELECT * FROM third",
+          )
+          adapter.create_materialized_view(
+            "x_fourth",
+            "SELECT * FROM fourth_1",
+          )
+          adapter.create_materialized_view(
+            "fourth",
+            "SELECT * FROM fourth_1 UNION SELECT * FROM x_fourth",
+          )
 
-        adapter.create_materialized_view(
-          "second",
-          "SELECT * from first",
-        )
+          expect(adapter).to receive(:refresh_materialized_view)
+            .with("public.first").ordered
+          expect(adapter).to receive(:refresh_materialized_view)
+            .with("public.second").ordered
+          expect(adapter).to receive(:refresh_materialized_view)
+            .with("public.third").ordered
+          expect(adapter).to receive(:refresh_materialized_view)
+            .with("public.fourth_1").ordered
+          expect(adapter).to receive(:refresh_materialized_view)
+            .with("public.x_fourth").ordered
+        end
 
-        adapter.create_materialized_view(
-          "third",
-          "SELECT * from first UNION SELECT * from second",
-        )
+        it "refreshes in the right order when called without namespace" do
+          described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
+        end
 
-        adapter.create_materialized_view(
-          "fourth",
-          "SELECT * from third",
-        )
-
-        expect(adapter).to receive(:refresh_materialized_view)
-          .with("public.first").ordered
-
-        expect(adapter).to receive(:refresh_materialized_view)
-          .with("public.second").ordered
-
-        expect(adapter).to receive(:refresh_materialized_view)
-          .with("public.third").ordered
-
-        described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
+        it "refreshes in the right order when called with namespace" do
+          described_class.call(
+            "public.fourth",
+            adapter,
+            ActiveRecord::Base.connection,
+          )
+        end
       end
 
-      it "does not raise an error when a view has no materialized view dependencies" do
-        adapter = Postgres.new
+      context "view has no dependencies" do
+        it "does not raise an error" do
+          adapter = Postgres.new
 
-        adapter.create_materialized_view(
-          "first",
-          "SELECT text 'hi' AS greeting",
-        )
+          adapter.create_materialized_view(
+            "first",
+            "SELECT text 'hi' AS greeting",
+          )
 
-        expect {
-          described_class.call(:first, adapter, ActiveRecord::Base.connection)
-        }.not_to raise_error
+          expect {
+            described_class.call(:first, adapter, ActiveRecord::Base.connection)
+          }.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
Addresses #258 - cascade failing to identify dependent views when the
`view_to_refresh` is a substring of a dependency.

Based off of #259.