### PR TITLE
Handle semicolon when using `no_data: true`

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -134,9 +134,10 @@ module Scenic
       # @return [void]
       def create_materialized_view(name, sql_definition, no_data: false)
         raise_unless_materialized_views_supported
+
         execute <<-SQL
   CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS
-  #{sql_definition}
+  #{sql_definition.rstrip.chomp(';')}
   #{'WITH NO DATA' if no_data};
         SQL
       end

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -27,6 +27,20 @@ module Scenic
           expect(view.materialized).to eq true
         end
 
+        it "handles semicolon in definition when using `with no data`" do
+          adapter = Postgres.new
+
+          adapter.create_materialized_view(
+            "greetings",
+            "SELECT text 'hi' AS greeting; \n",
+            no_data: true,
+          )
+
+          view = adapter.views.first
+          expect(view.name).to eq("greetings")
+          expect(view.materialized).to eq true
+        end
+
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)
           connectable = double("Connectable", connection: connection)


### PR DESCRIPTION
Some folks add `;` to the end of their view definitions to terminate the
statement. When this is combined with `no_data: true`, an exception was
being raised because `WITH NO DATA` was being interprested as a
separate SQL statement.

To fix this, we remove the trailing semicolon from the SQL definition
before adding `WITH NO DATA`.

Fixes #272