### PR TITLE
Fix a couple of bugs around schema qualified view names

### DIFF
--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -73,6 +73,12 @@ module Scenic
 
       private
 
+      alias singular_name file_name
+
+      def file_name
+        super.tr(".", "_")
+      end
+
       def views_directory_path
         @views_directory_path ||= Rails.root.join("db", "views")
       end
@@ -91,10 +97,6 @@ module Scenic
 
       def previous_definition
         Scenic::Definition.new(plural_file_name, previous_version)
-      end
-
-      def plural_file_name
-        @plural_file_name ||= file_name.pluralize.tr(".", "_")
       end
 
       def destroying?

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -29,7 +29,7 @@ module Scenic
     private
 
     def filename
-      "#{@name}_v#{version}.sql"
+      "#{@name.to_s.tr('.', '_')}_v#{version}.sql"
     end
   end
 end

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -38,14 +38,20 @@ describe Scenic::Generators::ViewGenerator, :generator do
   end
 
   context "for views created in a schema other than 'public'" do
-    it "creates view definition and migration files" do
-      migration = file("db/migrate/create_non_public_searches.rb")
+    it "creates a view definition" do
       view_definition = file("db/views/non_public_searches_v01.sql")
 
       run_generator ["non_public.search"]
 
-      expect(migration).to be_a_migration
       expect(view_definition).to exist
+    end
+
+    it "creates a migration file" do
+      run_generator ["non_public.search"]
+
+      migration = migration_file("db/migrate/create_non_public_searches.rb")
+      expect(migration).to contain(/class CreateNonPublicSearches/)
+      expect(migration).to contain(/create_view "non_public.searches"/)
     end
   end
 end

--- a/spec/scenic/definition_spec.rb
+++ b/spec/scenic/definition_spec.rb
@@ -29,6 +29,12 @@ module Scenic
 
         expect(definition.path).to eq expected
       end
+
+      it "handles schema qualified view names" do
+        definition = Definition.new("non_public.searches", 1)
+
+        expect(definition.path).to eq "db/views/non_public_searches_v01.sql"
+      end
     end
 
     describe "full_path" do


### PR DESCRIPTION
585ff85c5f5aee7e5ba0f5b13d806ed9fc109f20 - Fixes an issue where the generated migration for a schema qualified view name is not properly camelized.

```
$ rails g scenic:view non_public.search
      create  db/views/non_public_searches_v01.sql
      create  db/migrate/20190830220558_create_non_public_searches.rb
$ head db/migrate/20190830220558_create_non_public_searches.rb
class CreateNonPublicsearches < ActiveRecord::Migration[5.1]
  def change
    create_view "non_public.searches"
  end
end
```

The generated class name should be `CreateNonPublicSearches` instead of `CreateNonPublicsearches`.

585ff85c5f5aee7e5ba0f5b13d806ed9fc109f20 - Fixes an issue where, having generated a scenic view for a schema qualified view and editing its view definition, running `rake db:migrate` fails to find the view definition.

```
$ rails g scenic:view non_public.search
      create  db/views/non_public_searches_v01.sql
      create  db/migrate/20190830220558_create_non_public_searches.rb
$ vim db/views/non_public_searches_v01.sql
$ bundle exec rake db:migrate
== 20190830220558 CreateNonPublicSearches: migrating ==========================
-- create_view("non_public.searches")
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

No such file or directory @ rb_sysopen - /Users/brianchhun/.../db/views/non_public.searches_v01.sql
/Users/brianchhun/.../db/migrate/20190830220558_create_non_public_searches.rb:3:in `change'
/Users/brianchhun/.rbenv/versions/2.4.3/bin/bundle:23:in `load'
/Users/brianchhun/.rbenv/versions/2.4.3/bin/bundle:23:in `<main>'

Caused by:
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/brianchhun/.../db/views/non_public.searches_v01.sql
/Users/brianchhun/.../db/migrate/20190830220558_create_non_public_searches.rb:3:in `change'
/Users/brianchhun/.rbenv/versions/2.4.3/bin/bundle:23:in `load'
/Users/brianchhun/.rbenv/versions/2.4.3/bin/bundle:23:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```