### PR TITLE
Allows you to override the root path directly on a per-instance basis

### DIFF
--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -4,7 +4,7 @@ module Scenic
     def initialize(name, version, root_path: Rails.root)
       @name = name
       @version = version.to_i
-      @root_path = root_path
+      @root_path = root_path.is_a?(String) ? Pathname.new(root_path) : root_path
     end
 
     def to_sql

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -1,9 +1,10 @@
 module Scenic
   # @api private
   class Definition
-    def initialize(name, version)
+    def initialize(name, version, root_path: Rails.root)
       @name = name
       @version = version.to_i
+      @root_path = root_path
     end
 
     def to_sql
@@ -15,7 +16,7 @@ module Scenic
     end
 
     def full_path
-      Rails.root.join(path)
+      @root_path.join(path)
     end
 
     def path

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -22,7 +22,7 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false)
+    def create_view(name, version: nil, sql_definition: nil, materialized: false, root_path: Rails.root)
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -34,7 +34,8 @@ module Scenic
         version = 1
       end
 
-      sql_definition ||= definition(name, version)
+      sql_definition ||= definition(name, version, root_path: root_path)
+
 
       if materialized
         Scenic.database.create_materialized_view(
@@ -88,7 +89,7 @@ module Scenic
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false, root_path: Rails.root)
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -103,7 +104,7 @@ module Scenic
         )
       end
 
-      sql_definition ||= definition(name, version)
+      sql_definition ||= definition(name, version, root_path: root_path)
 
       if materialized
         Scenic.database.update_materialized_view(
@@ -132,7 +133,7 @@ module Scenic
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def replace_view(name, version: nil, revert_to_version: nil, materialized: false)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false, root_path: Rails.root)
       if version.blank?
         raise ArgumentError, "version is required"
       end
@@ -141,15 +142,15 @@ module Scenic
         raise ArgumentError, "Cannot replace materialized views"
       end
 
-      sql_definition = definition(name, version)
+      sql_definition = definition(name, version, root_path: root_path)
 
       Scenic.database.replace_view(name, sql_definition)
     end
 
     private
 
-    def definition(name, version)
-      Scenic::Definition.new(name, version).to_sql
+    def definition(name, version, root_path: Rails.root)
+      Scenic::Definition.new(name, version, root_path: root_path).to_sql
     end
 
     def no_data(materialized)

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -36,7 +36,6 @@ module Scenic
 
       sql_definition ||= definition(name, version, root_path: root_path)
 
-
       if materialized
         Scenic.database.create_materialized_view(
           name,

--- a/spec/scenic/definition_spec.rb
+++ b/spec/scenic/definition_spec.rb
@@ -37,6 +37,13 @@ module Scenic
 
         expect(definition.full_path).to eq Rails.root.join(definition.path)
       end
+
+      it "joins the path with whatever root you pass in" do
+        new_root = Pathname.new("component/engine/test/dummy")
+        definition = Definition.new("searches", 15, root_path: new_root)
+
+        expect(definition.full_path).to eq new_root.join(definition.path)
+      end
     end
 
     describe "version" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -12,10 +12,24 @@ module Scenic
         version = 15
         definition_stub = instance_double("Definition", to_sql: "foo")
         allow(Definition).to receive(:new)
-          .with(:views, version)
+          .with(:views, version, root_path: Rails.root)
           .and_return(definition_stub)
 
         connection.create_view :views, version: version
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, definition_stub.to_sql)
+      end
+
+      it "creates a view from a file and alternate root_path" do
+        version = 15
+        root_path = Pathname.new("component/engine/test/dummy")
+        definition_stub = instance_double("Definition", to_sql: "foo")
+        allow(Definition).to receive(:new)
+          .with(:views, version, root_path: root_path)
+          .and_return(definition_stub)
+
+        connection.create_view :views, version: version, root_path: root_path
 
         expect(Scenic.database).to have_received(:create_view)
           .with(:views, definition_stub.to_sql)
@@ -34,7 +48,7 @@ module Scenic
         version = 1
         definition_stub = instance_double("Definition", to_sql: "foo")
         allow(Definition).to receive(:new)
-          .with(:views, version)
+          .with(:views, version, root_path: Rails.root)
           .and_return(definition_stub)
 
         connection.create_view :views
@@ -98,10 +112,23 @@ module Scenic
       it "updates the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, root_path: Rails.root)
           .and_return(definition)
 
         connection.update_view(:name, version: 3)
+
+        expect(Scenic.database).to have_received(:update_view)
+          .with(:name, definition.to_sql)
+      end
+
+      it "updates the view in the database with an alternate path" do
+        root_path = Pathname.new("component/engine/test/dummy")
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3, root_path: root_path)
+          .and_return(definition)
+
+        connection.update_view(:name, version: 3, root_path: root_path)
 
         expect(Scenic.database).to have_received(:update_view)
           .with(:name, definition.to_sql)
@@ -119,7 +146,7 @@ module Scenic
       it "updates the materialized view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, root_path: Rails.root)
           .and_return(definition)
 
         connection.update_view(:name, version: 3, materialized: true)
@@ -131,7 +158,7 @@ module Scenic
       it "updates the materialized view in the database with NO DATA" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, root_path: Rails.root)
           .and_return(definition)
 
         connection.update_view(
@@ -166,10 +193,23 @@ module Scenic
       it "replaces the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, root_path: Rails.root)
           .and_return(definition)
 
         connection.replace_view(:name, version: 3)
+
+        expect(Scenic.database).to have_received(:replace_view)
+          .with(:name, definition.to_sql)
+      end
+
+      it "replaces the view in the database with an alternate path" do
+        root_path = Pathname.new("component/engine/test/dummy")
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3, root_path: root_path)
+          .and_return(definition)
+
+        connection.replace_view(:name, version: 3, root_path: root_path)
 
         expect(Scenic.database).to have_received(:replace_view)
           .with(:name, definition.to_sql)


### PR DESCRIPTION
This helps in situations where you are creating or updating views from within a Rails engine. By adding the `root_path` to the statement it will be able to correctly find the file.

The `, root_path: Database::Engine.root` is the part that is manually added. I didn't find any method of autodetecting the rails engine so this would have to be manually added after generating the migration.

# create_view
```
create_view :product_stats, version: 2, root_path: Database::Engine.root
```

# update_view
```
update_view :product_stats, version: 2, revert_to_version: 1, root_path: Database::Engine.root
```

# replace_view
```
replace_view :product_stats, version: 2, revert_to_version: 1, root_path: Database::Engine.root
```