### PR TITLE
Allow cascading refreshes to be done concurrently

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -209,8 +209,9 @@ module Scenic
       # @return [void]
       def refresh_materialized_view(name, concurrently: false, cascade: false)
         raise_unless_materialized_views_supported
+
         if cascade
-          refresh_dependencies_for(name)
+          refresh_dependencies_for(name, concurrently: concurrently)
         end
 
         if concurrently
@@ -242,11 +243,12 @@ module Scenic
         end
       end
 
-      def refresh_dependencies_for(name)
+      def refresh_dependencies_for(name, concurrently: false)
         Scenic::Adapters::Postgres::RefreshDependencies.call(
           name,
           self,
           connection,
+          concurrently: concurrently,
         )
       end
     end

--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -2,25 +2,29 @@ module Scenic
   module Adapters
     class Postgres
       class RefreshDependencies
-        def self.call(name, adapter, connection)
-          new(name, adapter, connection).call
+        def self.call(name, adapter, connection, concurrently: false)
+          new(name, adapter, connection, concurrently: concurrently).call
         end
 
-        def initialize(name, adapter, connection)
+        def initialize(name, adapter, connection, concurrently:)
           @name = name
           @adapter = adapter
           @connection = connection
+          @concurrently = concurrently
         end
 
         def call
           dependencies.each do |dependency|
-            adapter.refresh_materialized_view(dependency)
+            adapter.refresh_materialized_view(
+              dependency,
+              concurrently: concurrently,
+            )
           end
         end
 
         private
 
-        attr_reader :name, :adapter, :connection
+        attr_reader :name, :adapter, :connection, :concurrently
 
         class DependencyParser
           def initialize(raw_dependencies, view_to_refresh)

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -33,19 +33,24 @@ module Scenic
           )
 
           expect(adapter).to receive(:refresh_materialized_view)
-            .with("public.first").ordered
+            .with("public.first", concurrently: true).ordered
           expect(adapter).to receive(:refresh_materialized_view)
-            .with("public.second").ordered
+            .with("public.second", concurrently: true).ordered
           expect(adapter).to receive(:refresh_materialized_view)
-            .with("public.third").ordered
+            .with("public.third", concurrently: true).ordered
           expect(adapter).to receive(:refresh_materialized_view)
-            .with("public.fourth_1").ordered
+            .with("public.fourth_1", concurrently: true).ordered
           expect(adapter).to receive(:refresh_materialized_view)
-            .with("public.x_fourth").ordered
+            .with("public.x_fourth", concurrently: true).ordered
         end
 
         it "refreshes in the right order when called without namespace" do
-          described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
+          described_class.call(
+            :fourth,
+            adapter,
+            ActiveRecord::Base.connection,
+            concurrently: true,
+          )
         end
 
         it "refreshes in the right order when called with namespace" do
@@ -53,6 +58,7 @@ module Scenic
             "public.fourth",
             adapter,
             ActiveRecord::Base.connection,
+            concurrently: true,
           )
         end
       end

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -119,8 +119,14 @@ module Scenic
           connectable = double("Connectable", connection: connection)
           adapter = Postgres.new(connectable)
           expect(Scenic::Adapters::Postgres::RefreshDependencies)
-            .to receive(:call).with(:tests, adapter, connection)
-          adapter.refresh_materialized_view(:tests, cascade: true)
+            .to receive(:call)
+            .with(:tests, adapter, connection, concurrently: true)
+
+          adapter.refresh_materialized_view(
+            :tests,
+            cascade: true,
+            concurrently: true,
+          )
         end
 
         context "refreshing concurrently" do


### PR DESCRIPTION
Previous to this change, using the cascading refresh behavior did not
also pass through the option to concurrently refresh as one would
expect. This meant that while the named view would be refreshed
concurrently when desired, none of its dependencies would.

Fixes #276