### PR TITLE
Make `create_view` with `version` reversible

### DIFF
--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -20,7 +20,8 @@ module Scenic
     end
 
     def invert_create_view(args)
-      [:drop_view, args]
+      drop_view_args = StatementArguments.new(args).remove_version.to_a
+      [:drop_view, drop_view_args]
     end
 
     def invert_drop_view(args)

--- a/lib/scenic/command_recorder/statement_arguments.rb
+++ b/lib/scenic/command_recorder/statement_arguments.rb
@@ -22,8 +22,12 @@ module Scenic
         StatementArguments.new([view, options_for_revert])
       end
 
+      def remove_version
+        StatementArguments.new([view, options_without_version])
+      end
+
       def to_a
-        @args.to_a
+        @args.to_a.dup.delete_if(&:empty?)
       end
 
       private
@@ -37,6 +41,10 @@ module Scenic
           revert_options[:version] = revert_to_version
           revert_options.delete(:revert_to_version)
         end
+      end
+
+      def options_without_version
+        options.except(:version)
       end
     end
   end

--- a/spec/scenic/command_recorder_spec.rb
+++ b/spec/scenic/command_recorder_spec.rb
@@ -8,10 +8,24 @@ describe Scenic::CommandRecorder do
       expect(recorder.commands).to eq [[:create_view, [:greetings], nil]]
     end
 
-    it "reverts to drop_view" do
+    it "reverts to drop_view when not passed a version" do
       recorder.revert { recorder.create_view :greetings }
 
       expect(recorder.commands).to eq [[:drop_view, [:greetings]]]
+    end
+
+    it "reverts to drop_view when passed a version" do
+      recorder.revert { recorder.create_view :greetings, version: 2 }
+
+      expect(recorder.commands).to eq [[:drop_view, [:greetings]]]
+    end
+
+    it "reverts materialized views appropriately" do
+      recorder.revert { recorder.create_view :greetings, materialized: true }
+
+      expect(recorder.commands).to eq [
+        [:drop_view, [:greetings, materialized: true]],
+      ]
     end
   end
 


### PR DESCRIPTION
Prior to this change, `create_view :greetings, version: 2` would error
because it was reversed to `drop_view :greetings, version: 2`. The
`drop_view` method on the Postgres adapter only takes a view name, so we
shouldn't record additional arguments when inverting.