### PR TITLE
Update oracle adapter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ meet your needs:
 * [scenic_sqlite_adapter](https://github.com/pdebelak/scenic_sqlite_adapter)
 * [scenic-mysql_adapter](https://github.com/EmpaticoOrg/scenic-mysql_adapter)
 * [scenic-sqlserver-adapter](https://github.com/ClickMechanic/scenic_sqlserver_adapter)
-* [scenic-oracle_enhanced_adapter](https://github.com/PMACS/scenic_oracle_enhanced_adapter)
+* [scenic-oracle_adapter](https://github.com/cdinger/scenic-oracle_adapter)
 
 ## About
 


### PR DESCRIPTION
Replace reference to no-longer-available gem. 'scenic-oracle_enhanced_adapter' has been pulled from rubygems. 'scenic-oracle_adapter' is a current, maintained alternative.