### PR TITLE
Implement custom views path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ changelog, see the [commits] for each version via the version links.
 
 [commits]: https://github.com/scenic-views/scenic/commits/master
 
+## [Unreleased]
+
+Added
+
+* Add a configuration value for changing the default path for the views files
+
+[Unreleased]: https://github.com/scenic-views/scenic/compare/v1.5.2...master
+
 ## [1.5.2] - February 6, 2020
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,23 @@ def change
 end
 ```
 
+## Configuring Scenic
+
+Currently there's two things that can be set up on this gem:
+
+* `adapter` defines which adapter will be used to control the views on your database. By default we only provide and support for PostgreSQL, but you can set up other third-party adapters here
+
+* `views_path` defines where the view SQL files will be saved. The defalt is on `db/views` on your Rails path.
+
+To edit those values, create a `scenic.rb` file on your initialize directory and add the above code:
+
+```ruby
+Scenic.configure do |config|
+  config.database = MyDatabaseAdapter.new
+  config.views_path = 'my/path/to/view/files'
+end
+```
+
 ## FAQs
 
 **Why do I get an error when querying a view-backed model with `find`, `last`, or `first`?**

--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -29,4 +29,12 @@ module Scenic
   def self.database
     configuration.database
   end
+
+  # The current path for the views files.
+  #
+  # This defaults to 'db/views', but can be overridden
+  # via {Configuration}.
+  def self.views_path
+    configuration.views_path
+  end
 end

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -1,13 +1,26 @@
 module Scenic
   class Configuration
+    # Set the default path to store the views.
+    #
+    # Defaults to db/views on Rails root
+    DEFAULT_VIEWS_PATH = "db/views".freeze
+
     # The Scenic database adapter instance to use when executing SQL.
     #
     # Defaults to an instance of {Adapters::Postgres}
     # @return Scenic adapter
     attr_accessor :database
 
+    # The Scenic database adapter instance to use when executing SQL.
+    # The path where the views SQL files are stored
+    #
+    # Defaults to 'db/views'
+    # @return string
+    attr_accessor :views_path
+
     def initialize
       @database = Scenic::Adapters::Postgres.new
+      @views_path = DEFAULT_VIEWS_PATH
     end
   end
 

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -19,7 +19,7 @@ module Scenic
     end
 
     def path
-      File.join("db", "views", filename)
+      File.join(Scenic.views_path, filename)
     end
 
     def version

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -54,4 +54,33 @@ describe Scenic::Generators::ViewGenerator, :generator do
       expect(migration).to contain(/create_view "non_public.searches"/)
     end
   end
+
+  context "for migrations using another view path" do
+    before do
+      Scenic.configure do |config|
+        config.views_path = "lib/dbms/views"
+      end
+    end
+
+    after { Scenic.configuration = Scenic::Configuration.new }
+
+    it "creates view files" do
+      view_definition = file("lib/dbms/views/searches_v01.sql")
+
+      run_generator ["search"]
+
+      expect(view_definition).to exist
+    end
+
+    it "updates an existing view" do
+      with_view_definition("searches", 1, "hello") do
+        view_definition = file("lib/dbms/views/searches_v02.sql")
+        allow(Dir).to receive(:entries).and_return(["searches_v01.sql"])
+
+        run_generator ["search"]
+
+        expect(view_definition).to exist
+      end
+    end
+  end
 end

--- a/spec/scenic/configuration_spec.rb
+++ b/spec/scenic/configuration_spec.rb
@@ -20,6 +20,17 @@ module Scenic
       expect(Scenic.database).to eq adapter
     end
 
+    it "allows the views path to be set" do
+      path = "db/pg/views"
+
+      Scenic.configure do |config|
+        config.views_path = path
+      end
+
+      expect(Scenic.configuration.views_path).to eq path
+      expect(Scenic.views_path).to eq path
+    end
+
     def restore_default_config
       Scenic.configuration = Configuration.new
     end


### PR DESCRIPTION
Hi there!

Here at work we use two database adapters, SQL Server and SQLite (for quick tests before CI/CD). Since some syntax between those two are incompatible, we need to have two SQL files, and those can't live in the same directory.

The best solution we found was to add a configuration attribute to define the views path directory, so we can edit it inside Rails like that:

```ruby
adapter = Rails.env.test? ? 'sqlite' : 'sqlserver'

Scenic.configure do |config|
  config.views_path = "db/views/#{adapter}"
end
```

Since more people could benefit from this change, I've decided to open a PR.
Let me know if it's is OK or if I missed something 😃