### PR TITLE
Fix Ruby 2.4 builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ end
 
 gem "rails", rails_constraint
 gem "sprockets", "< 4.0.0"
+gem "pg", "~> 1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ else
 end
 
 gem "rails", rails_constraint
+gem "sprockets", "< 4.0.0"


### PR DESCRIPTION
Ruby 2.4 builds are failing because the latest major version of Sprokets
is not installable on Ruby 2.4. We don't care about sprockets as a
dependency in Scenic, so I've pinned it to a compatible version for now.
When we stop testing on Ruby 2.4, we can remove this.
