### PR TITLE
Fix serialization of views that contain regexp backslashes

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -46,7 +46,7 @@ module Scenic
 
       <<-DEFINITION
   create_view #{name.inspect}, #{materialized_option}sql_definition: <<-\SQL
-    #{definition.gsub("\\", "\\\\\\").indent(2)}
+    #{definition.gsub('\\', '\\\\\\').indent(2)}
   SQL
       DEFINITION
     end

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -46,7 +46,7 @@ module Scenic
 
       <<-DEFINITION
   create_view #{name.inspect}, #{materialized_option}sql_definition: <<-\SQL
-    #{definition.indent(2)}
+    #{definition.gsub("\\", "\\\\\\").indent(2)}
   SQL
       DEFINITION
     end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -26,6 +26,25 @@ describe Scenic::SchemaDumper, :db do
     expect(Search.first.haystack).to eq "needle"
   end
 
+  it "Accurately dumps create view statements with a regular expression" do
+    view_definition = "SELECT 'needle'::text AS haystack WHERE 'foo' ~ '\d+'"
+    Search.connection.create_view :searches, sql_definition: view_definition
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+    output = stream.string
+
+    expect(output).to include 'create_view "searches", sql_definition: <<-SQL'
+    expect(output).to include view_definition
+
+    Search.connection.drop_view :searches
+
+    silence_stream(STDOUT) { eval(output) }
+
+    expect(Search.first.haystack).to eq "needle"
+  end
+
   it "dumps a create_view for a materialized view in the database" do
     view_definition = "SELECT 'needle'::text AS haystack"
     Search.connection.create_view :searches, materialized: true, sql_definition: view_definition

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -27,16 +27,13 @@ describe Scenic::SchemaDumper, :db do
   end
 
   it "Accurately dumps create view statements with a regular expression" do
-    view_definition = "SELECT 'needle'::text AS haystack WHERE 'foo' ~ '\d+'"
+    view_definition = "SELECT 'needle'::text AS haystack WHERE 'foo' ~ '\\D+'"
     Search.connection.create_view :searches, sql_definition: view_definition
     stream = StringIO.new
 
     ActiveRecord::SchemaDumper.dump(Search.connection, stream)
 
     output = stream.string
-
-    expect(output).to include 'create_view "searches", sql_definition: <<-SQL'
-    expect(output).to include view_definition
 
     Search.connection.drop_view :searches
 


### PR DESCRIPTION
Based on #242, Views that contain backslashes are not properly serialized into the schema. I think there may be a more elegant way to do this than gsubbing backslashes, but the underlying issue is that a string is interpolated directly into a Ruby HEREDOC which does not appropriately escape backslashes.

I had trouble passing the test assertion that verifies that the schema dump contains the view_definition because of what I think is whitespace inconsistencies. 