### PR TITLE
Configurable root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ meet your needs:
 Please note that the maintainers of Scenic make no assertions about the
 quality or security of the above adapters.
 
+**Can I use Scenic in Rails engines?**
+
+Yes, just update the path where Scenic looks up its views in its configuration:
+
+```ruby
+Scenic.configure do |config|
+  config.root_path = MyEngine.root
+end
+```
+
 ## About
 
 Scenic is maintained by [Derek Prior], [Caleb Hearth], and you, our

--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -29,4 +29,12 @@ module Scenic
   def self.database
     configuration.database
   end
+
+  # The path where Scenic looks up its views
+  #
+  # This default to {Rails.root} but can be overridden
+  # via {Configuration}.
+  def self.root_path
+    configuration.root_path
+  end
 end

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -4,10 +4,11 @@ module Scenic
     #
     # Defaults to an instance of {Adapters::Postgres}
     # @return Scenic adapter
-    attr_accessor :database
+    attr_accessor :database, :root_path
 
     def initialize
       @database = Scenic::Adapters::Postgres.new
+      @root_path = Rails.root
     end
   end
 
@@ -29,6 +30,7 @@ module Scenic
   # ```
   # Scenic.configure do |config|
   #   config.database = Scenic::Adapters::Postgres.new
+  #   config.root_path = MyEngine.root
   # end
   # ```
   def self.configure

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -15,7 +15,7 @@ module Scenic
     end
 
     def full_path
-      Rails.root.join(path)
+      Pathname.new(File.join(Scenic.root_path, path))
     end
 
     def path

--- a/spec/support/generator_spec_setup.rb
+++ b/spec/support/generator_spec_setup.rb
@@ -7,6 +7,7 @@ RSpec.configure do |config|
   config.before(:example, :generator) do
     fake_rails_root = File.expand_path("../../tmp", __dir__)
     allow(Rails).to receive(:root).and_return(Pathname.new(fake_rails_root))
+    allow(Scenic).to receive(:root_path).and_return(Pathname.new(fake_rails_root))
 
     destination fake_rails_root
     prepare_destination

--- a/spec/support/generator_spec_setup.rb
+++ b/spec/support/generator_spec_setup.rb
@@ -6,8 +6,9 @@ require "ammeter/init"
 RSpec.configure do |config|
   config.before(:example, :generator) do
     fake_rails_root = File.expand_path("../../tmp", __dir__)
-    allow(Rails).to receive(:root).and_return(Pathname.new(fake_rails_root))
-    allow(Scenic).to receive(:root_path).and_return(Pathname.new(fake_rails_root))
+    fake_rails_root_pathname = Pathname.new(fake_rails_root)
+    allow(Rails).to receive(:root).and_return(fake_rails_root_pathname)
+    allow(Scenic).to receive(:root_path).and_return(fake_rails_root_pathname)
 
     destination fake_rails_root
     prepare_destination


### PR DESCRIPTION
This PR allows for configuration of the root path, where Scenic looks up its views:

```ruby
Scenic.configure do |config|
  config.root_path = MyEngine.root
end
```

The default value stays `Rails.root`.

This is a follow up to https://github.com/scenic-views/scenic/pull/237#issuecomment-513880655 and addresses #261.