### PR TITLE
Allow view creation using raw SQL input

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ you would need to refresh view B first, then right after refresh view A. If you
 would like this cascading refresh of materialized views, set `cascade: true`
 when you refresh your materialized view.
 
+## What if I need unfettered control?
+
+Scenic makes writing views easy by adding the necessary `CREATE VIEW…` syntax
+around your `SELECT` query. Most of the time this is great but it prevents you
+from splitting your view query into multiple statements.
+
+You can pass `raw: true` to `create_view`, doing so leaves you free (and
+responsible) to build set up your view creation as needed. An example of when
+this can be useful is when creating complex views that benefits from being
+abstracted into sub views. While this can be done by creating several Scenic
+view migrations it can make it more easy to maintain when all statements to a
+view reside in the same .sql file.
+
 ## I don't need this view anymore. Make it go away.
 
 Scenic gives you `drop_view` too:

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -57,8 +57,12 @@ module Scenic
       # @param sql_definition The SQL schema for the view.
       #
       # @return [void]
-      def create_view(name, sql_definition)
-        execute "CREATE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+      def create_view(name, sql_definition, raw: false)
+        if raw
+          execute(sql_definition)
+        else
+          execute "CREATE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+        end
       end
 
       # Updates a view in the database.
@@ -132,14 +136,18 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def create_materialized_view(name, sql_definition, no_data: false)
+      def create_materialized_view(name, sql_definition, no_data: false, raw: false)
         raise_unless_materialized_views_supported
 
-        execute <<-SQL
-  CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS
-  #{sql_definition.rstrip.chomp(';')}
-  #{'WITH NO DATA' if no_data};
-        SQL
+        if raw
+          execute(sql_definition)
+        else
+          execute <<-SQL
+    CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS
+    #{sql_definition.rstrip.chomp(';')}
+    #{'WITH NO DATA' if no_data};
+          SQL
+        end
       end
 
       # Updates a materialized view in the database.

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -136,7 +136,12 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def create_materialized_view(name, sql_definition, no_data: false, raw: false)
+      def create_materialized_view(
+        name,
+        sql_definition,
+        no_data: false,
+        raw: false
+      )
         raise_unless_materialized_views_supported
 
         if raw

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -22,7 +22,7 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false)
+    def create_view(name, version: nil, sql_definition: nil, materialized: false, raw: false)
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -41,9 +41,10 @@ module Scenic
           name,
           sql_definition,
           no_data: no_data(materialized),
+          raw: raw
         )
       else
-        Scenic.database.create_view(name, sql_definition)
+        Scenic.database.create_view(name, sql_definition, raw: raw)
       end
     end
 
@@ -60,7 +61,7 @@ module Scenic
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    def drop_view(name, revert_to_version: nil, materialized: false, raw: nil)
       if materialized
         Scenic.database.drop_materialized_view(name)
       else

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -22,7 +22,13 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false, raw: false)
+    def create_view(
+      name,
+      version: nil,
+      sql_definition: nil,
+      materialized: false,
+      raw: false
+    )
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -41,7 +47,7 @@ module Scenic
           name,
           sql_definition,
           no_data: no_data(materialized),
-          raw: raw
+          raw: raw,
         )
       else
         Scenic.database.create_view(name, sql_definition, raw: raw)

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -15,7 +15,11 @@ module Scenic
         it "successfully creates a view with raw input" do
           adapter = Postgres.new
 
-          adapter.create_view("greetings", "CREATE VIEW greetings AS SELECT text 'hi' AS greeting", raw: true)
+          adapter.create_view(
+            "greetings",
+            "CREATE VIEW greetings AS SELECT text 'hi' AS greeting",
+            raw: true,
+          )
 
           expect(adapter.views.map(&:name)).to include("greetings")
         end
@@ -62,7 +66,11 @@ module Scenic
         it "successfully creates a materialized view with raw input" do
           adapter = Postgres.new
 
-          adapter.create_view("greetings", "CREATE MATERIALIZED VIEW greetings AS SELECT text 'hi' AS greeting", raw: true)
+          adapter.create_view(
+            "greetings",
+            "CREATE MATERIALIZED VIEW greetings AS SELECT text 'hi' AS greet",
+            raw: true,
+          )
 
           expect(adapter.views.map(&:name)).to include("greetings")
         end

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -11,6 +11,14 @@ module Scenic
 
           expect(adapter.views.map(&:name)).to include("greetings")
         end
+
+        it "successfully creates a view with raw input" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "CREATE VIEW greetings AS SELECT text 'hi' AS greeting", raw: true)
+
+          expect(adapter.views.map(&:name)).to include("greetings")
+        end
       end
 
       describe "#create_materialized_view" do
@@ -49,6 +57,14 @@ module Scenic
 
           expect { adapter.create_materialized_view("greetings", "select 1") }
             .to raise_error err
+        end
+
+        it "successfully creates a materialized view with raw input" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "CREATE MATERIALIZED VIEW greetings AS SELECT text 'hi' AS greeting", raw: true)
+
+          expect(adapter.views.map(&:name)).to include("greetings")
         end
       end
 

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -18,7 +18,7 @@ module Scenic
         connection.create_view :views, version: version
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql)
+          .with(:views, definition_stub.to_sql, raw: false)
       end
 
       it "creates a view from a text definition" do
@@ -27,7 +27,16 @@ module Scenic
         connection.create_view(:views, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition)
+          .with(:views, sql_definition, raw: false)
+      end
+
+      it "creates a view from a text definition with raw option" do
+        sql_definition = "a defintion"
+
+        connection.create_view(:views, sql_definition: sql_definition, raw: true)
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition, raw: true)
       end
 
       it "creates version 1 of the view if neither version nor sql_defintion are provided" do
@@ -40,7 +49,7 @@ module Scenic
         connection.create_view :views
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql)
+          .with(:views, definition_stub.to_sql, raw: false)
       end
 
       it "raises an error if both version and sql_defintion are provided" do
@@ -58,7 +67,7 @@ module Scenic
         connection.create_view(:views, version: 1, materialized: true)
 
         expect(Scenic.database).to have_received(:create_materialized_view)
-          .with(:views, definition.to_sql, no_data: false)
+          .with(:views, definition.to_sql, no_data: false, raw: false)
       end
     end
 
@@ -74,7 +83,24 @@ module Scenic
         )
 
         expect(Scenic.database).to have_received(:create_materialized_view)
-          .with(:views, definition.to_sql, no_data: true)
+          .with(:views, definition.to_sql, no_data: true, raw: false)
+      end
+    end
+
+    describe "create_view :materialized with :raw" do
+      it "sends the create_materialized_view message, passing on raw option" do
+        definition = instance_double("Scenic::Definition", to_sql: "definition")
+        allow(Definition).to receive(:new).and_return(definition)
+
+        connection.create_view(
+          :views,
+          version: 1,
+          materialized: { no_data: true},
+          raw: true
+        )
+
+        expect(Scenic.database).to have_received(:create_materialized_view)
+          .with(:views, definition.to_sql, no_data: true, raw: true)
       end
     end
 

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -33,7 +33,11 @@ module Scenic
       it "creates a view from a text definition with raw option" do
         sql_definition = "a defintion"
 
-        connection.create_view(:views, sql_definition: sql_definition, raw: true)
+        connection.create_view(
+          :views,
+          sql_definition: sql_definition,
+          raw: true,
+        )
 
         expect(Scenic.database).to have_received(:create_view)
           .with(:views, sql_definition, raw: true)
@@ -95,8 +99,8 @@ module Scenic
         connection.create_view(
           :views,
           version: 1,
-          materialized: { no_data: true},
-          raw: true
+          materialized: { no_data: true },
+          raw: true,
         )
 
         expect(Scenic.database).to have_received(:create_materialized_view)


### PR DESCRIPTION
This PR adds an option to `create_view` that allows users to gain full control of SQL statements used when build a view.

`create_view` helps the user by wrapping their `SELECT` statement into a `CREATE VIEW` statement. This is great in most cases but it breaks the ability to build complex views that depends on other views.

This can already be done by individually migrating several views. However I find that if the goal is to create a single complex view it's better to contain all the necessary subviews inside the same SQL file.

Read on for more details:

For an example on a query that fits the description please see this [gist](https://gist.github.com/ramhoj/da0ebd6398b519db045a9e65e12c6715). To create the same view in a single `SELECT` statement the same `CASE`  would be needed to be duplicated multiple times creating a nearly impossible to read query.

As I found myself going back and editing views needed for other views it became a lot of work to re-run multiple migrations every time. I also think it's more clean to contain all the necessary sql needed to create a view in this use case when there is only one view being considered "public".