### PR TITLE
Fix loading error on `Bundler.require`

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -1,3 +1,6 @@
+require "rails"
+require "active_record"
+
 require "scenic/configuration"
 require "scenic/adapters/postgres"
 require "scenic/command_recorder"

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -1,5 +1,3 @@
-require "rails"
-
 module Scenic
   # @api private
   module SchemaDumper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+Bundler.require
+
 ENV["RAILS_ENV"] = "test"
 require "database_cleaner"
 


### PR DESCRIPTION
Calling `Bundler.require` or `require 'scenic'` was throwing errors:
* `undefined method 'delegate' for Scenic::Adapters::Postgres::Indexes:Class`
* `uninitialized constant Scenic::SchemaDumper::ActiveRecord`

These errors don't happen when running rails commands since
`config/application.rb` requires 'rails' and 'active_record'
before calling `Bundler.require`.

It however prevents standalone scripts and executable (such as `sidekiqswarm`)
from calling `Bundler.require` before initializing the rails app.

Adding `Bundler.require` to `spec_helper.rb` reproduces this issue.