### PR TITLE
Update setup-ruby version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1.14.1
+        uses: ruby/setup-ruby@v1.61.1
         with:
           ruby-version: ${{ matrix.ruby }}
 


### PR DESCRIPTION
A naive update to latest to see if it works, it seems the old versions are no longer pulling ruby from the right URL https://github.com/scenic-views/scenic/pull/316/checks?check_run_id=1648933511