### PR TITLE
docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ agree to abide by our [code of conduct].
 6. CI will run the test suite on all configured versions of Ruby and Rails.
    Address any failures.
 
+you can also run it (step 2 and 3) localy with docker: `docker-compose run scenic rake`.
+
 [good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 Others will give constructive feedback.  This is a time for discussion and

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.7
+WORKDIR /app
+RUN apt-get install libpq-dev
+ADD Gemfile scenic.gemspec ./
+ADD lib/scenic/version.rb ./lib/scenic/
+RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  scenic:
+    build: .
+    volumes:
+      - .:/app
+    depends_on:
+      - postgres
+    networks:
+      default:
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+  postgres:
+    image: postgres
+    networks:
+      default:
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: dummy_test

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -2,12 +2,10 @@ development: &default
   adapter: postgresql
   database: dummy_development
   encoding: unicode
-  host: localhost
+  host: <%= ENV.fetch("POSTGRES_HOST", "localhost") %>
   pool: 5
-  <% if ENV.fetch("GITHUB_ACTIONS", false) %>
-  username: <%= ENV.fetch("POSTGRES_USER") %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
-  <% end %>
+  username: <%= ENV.fetch("POSTGRES_USER", "postgres") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
 
 test:
   <<: *default


### PR DESCRIPTION
add configuration to be able to run tests of scenic inside docker (doesn't prevent to continue to work as usual when everything is installed locally).

That allows to easily create and clean up the local setup needed to work on this gem with docker.