### PR TITLE
Use view without namespace when dumping schema.

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -15,7 +15,7 @@ module Scenic
 
       dumpable_views_in_database.each do |view|
         stream.puts(view.to_schema)
-        indexes(view.name, stream)
+        indexes(view.unscoped_name, stream)
       end
     end
 

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -41,11 +41,15 @@ module Scenic
     end
 
     # @api private
+    def unscoped_name
+      name.split('.').last
+    end
+
+    # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
-
       <<-DEFINITION
-  create_view #{name.inspect}, #{materialized_option}sql_definition: <<-\SQL
+  create_view #{unscoped_name.inspect}, #{materialized_option}sql_definition: <<-\SQL
     #{definition.indent(2)}
   SQL
       DEFINITION

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -40,7 +40,7 @@ describe Scenic::SchemaDumper, :db do
   end
 
   context "with views in non public schemas" do
-    it "dumps a create_view including namespace for a view in the database" do
+    it "dumps a create_view excluding namespace for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
       Search.connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
       Search.connection.create_view :"scenic.searches", sql_definition: view_definition
@@ -49,7 +49,7 @@ describe Scenic::SchemaDumper, :db do
       ActiveRecord::SchemaDumper.dump(Search.connection, stream)
 
       output = stream.string
-      expect(output).to include 'create_view "scenic.searches",'
+      expect(output).to include 'create_view "searches",'
 
       Search.connection.drop_view :'scenic.searches'
     end
@@ -89,7 +89,7 @@ describe Scenic::SchemaDumper, :db do
     end
   end
 
-  context "with views using unexpected characters, name including namespace" do
+  context "with views using unexpected characters, name excluding namespace" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
       Search.connection.execute(
@@ -102,7 +102,7 @@ describe Scenic::SchemaDumper, :db do
       ActiveRecord::SchemaDumper.dump(Search.connection, stream)
 
       output = stream.string
-      expect(output).to include 'create_view "scenic.\"search in a haystack\"",'
+      expect(output).to include 'create_view "\"search in a haystack\"",'
       expect(output).to include view_definition
 
       Search.connection.drop_view :'scenic."search in a haystack"'


### PR DESCRIPTION
## Why?

Without this, default behavior of `rake db:schema:load` is broken becuase Activerecord config option `schema search path` for Postgres adapters is automatically used to identify where is the schema being loaded to; By explicitly adding the namespace/search_path in the schema.rb it's wrong as you can run rake db:migrate from multiple computers and configurations which result in namespace_from_pc_1.view_name and namespace_from_pc_2.view_name on different commits.

## Changes

+ Added a new private method unscoped_view to make sure to not include the namespace when dumping the schema name
+ Updated tests to make sure the namespace is excluded rather than included.

## Extra

An additional justification is that schema.rb does not include namespaces ever, and the default Rails/Activerecord behavior should be conserved.

Fixes:  https://github.com/scenic-views/scenic/issues/325