### PR TITLE
Fix update_view statement from crashing with wrong method access.

### DIFF
--- a/lib/scenic/adapters/postgres/index_reapplication.rb
+++ b/lib/scenic/adapters/postgres/index_reapplication.rb
@@ -13,7 +13,7 @@ module Scenic
         # @param connection [Connection] The connection to execute SQL against.
         # @param speaker [#say] (ActiveRecord::Migration) The object used for
         #   logging the results of reapplying indexes.
-        def initialize(connection:, speaker: ActiveRecord::Migration)
+        def initialize(connection:, speaker: ActiveRecord::Migration.new)
           @connection = connection
           @speaker = speaker
         end


### PR DESCRIPTION
## Fixes bug and crash with update_view statement

Use `ActiveRecord::Migration` instance instead of class when creatin an `IndexReplication` object to prevent wrong method 
access when using `IndexReplication#speaker`.

## Why?
In short, using `update_view` in a migration crashes because `scenic` tries to do `IndexReplication#speaker#say` on the wrong object.

This happens because the `speaker` object is expected to be an **instance** of `ActiveRecord::Migration` but the `initializer` of `IndexReplication` actually assigns the **class** insteand, so it ends up trying to do `ActiveRecord::Migration::say` instead of `ActiveRecord::Migration#say`.

More info can be found on these comments: 
- https://github.com/scenic-views/scenic/issues/253#issuecomment-698306195
- https://github.com/scenic-views/scenic/issues/253#issuecomment-815184341

## Changes 

+ Make `speaker` default to a `new` **class instance** instead of just the **class**.

## Fixes https://github.com/scenic-views/scenic/issues/253