### PR TITLE
Fix #331: keywords are correctly passed in Ruby 2 and 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7","2.4"]
+        ruby: ["3.0", "2.7", "2.6", "2.4"]
         rails: ["5.2", "6.0", "master"]
         exclude:
           - ruby: "2.4"

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -6,18 +6,22 @@ module Scenic
     def create_view(*args)
       record(:create_view, args)
     end
+    ruby2_keywords :create_view if respond_to?(:ruby2_keywords, true)
 
     def drop_view(*args)
       record(:drop_view, args)
     end
+    ruby2_keywords :drop_view if respond_to?(:ruby2_keywords, true)
 
     def update_view(*args)
       record(:update_view, args)
     end
+    ruby2_keywords :update_view if respond_to?(:ruby2_keywords, true)
 
     def replace_view(*args)
       record(:replace_view, args)
     end
+    ruby2_keywords :replace_view if respond_to?(:ruby2_keywords, true)
 
     def invert_create_view(args)
       drop_view_args = StatementArguments.new(args).remove_version.to_a

--- a/lib/scenic/command_recorder/statement_arguments.rb
+++ b/lib/scenic/command_recorder/statement_arguments.rb
@@ -36,15 +36,26 @@ module Scenic
         @options ||= @args[1] || {}
       end
 
-      def options_for_revert
-        options.clone.tap do |revert_options|
-          revert_options[:version] = revert_to_version
-          revert_options.delete(:revert_to_version)
+      if Hash.respond_to? :ruby2_keywords_hash
+        def keyword_hash(hash)
+          Hash.ruby2_keywords_hash hash
+        end
+      else
+        def keyword_hash(hash)
+          hash
         end
       end
 
+      def options_for_revert
+        opts = options.clone.tap do |revert_options|
+          revert_options[:version] = revert_to_version
+          revert_options.delete(:revert_to_version)
+        end
+        keyword_hash opts
+      end
+
       def options_without_version
-        options.except(:version)
+        keyword_hash options.except(:version)
       end
     end
   end


### PR DESCRIPTION
For more context, see:

* https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
* https://github.com/scenic-views/scenic/issues/331
* https://github.com/rails/rails/issues/42653