### PR TITLE
Add topological sorting for dumped views using TSort

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -50,18 +50,22 @@ module Scenic
     private
 
     def dumpable_views_in_database
-      return @ordered_dumpable_views_in_database if @ordered_dumpable_views_in_database
+      if @ordered_dumpable_views_in_database
+        return @ordered_dumpable_views_in_database
+      end
 
       existing_views = Scenic.database.views.reject do |view|
         ignored?(view.name)
       end
 
-      @ordered_dumpable_views_in_database = tsorted_views(existing_views.map(&:name)).map do |view_name|
-        existing_views.find { |ev| ev.name == view_name }
-      end.compact
+      @ordered_dumpable_views_in_database =
+        tsorted_views(existing_views.map(&:name)).map do |view_name|
+          existing_views.find { |ev| ev.name == view_name }
+        end.compact
     end
 
-    # When dumping the views, their order must be topologically sorted to take into account dependencies
+    # When dumping the views, their order must be topologically
+    # sorted to take into account dependencies
     def tsorted_views(views_names)
       views_hash = TSortableHash.new
 
@@ -75,7 +79,8 @@ module Scenic
         views_names.delete(dependent)
       end
 
-      # after dependencies, there might be some views left that don't have any dependencies
+      # after dependencies, there might be some views left
+      # that don't have any dependencies
       views_names.sort.each { |v| views_hash[v] = [] }
 
       views_hash.tsort

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -3,6 +3,34 @@ require "rails"
 module Scenic
   # @api private
   module SchemaDumper
+    # A hash to do topological sort
+    class TSortableHash < Hash
+      include TSort
+
+      alias tsort_each_node each_key
+      def tsort_each_child(node, &block)
+        fetch(node).each(&block)
+      end
+    end
+
+    # Query for the dependencies between views
+    DEPENDENT_SQL = <<~SQL.freeze
+      SELECT distinct dependent_ns.nspname AS dependent_schema
+      , dependent_view.relname AS dependent_view
+      , source_ns.nspname AS source_schema
+      , source_table.relname AS source_table
+      FROM pg_depend
+      JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid
+      JOIN pg_class as dependent_view ON pg_rewrite.ev_class = dependent_view.oid
+      JOIN pg_class as source_table ON pg_depend.refobjid = source_table.oid
+      JOIN pg_namespace dependent_ns ON dependent_ns.oid = dependent_view.relnamespace
+      JOIN pg_namespace source_ns ON source_ns.oid = source_table.relnamespace
+      WHERE dependent_ns.nspname = ANY (current_schemas(false)) AND source_ns.nspname = ANY (current_schemas(false))
+      AND source_table.relname != dependent_view.relname
+      AND source_table.relkind IN ('m', 'v') AND dependent_view.relkind IN ('m', 'v')
+      ORDER BY dependent_view.relname;
+    SQL
+
     def tables(stream)
       super
       views(stream)
@@ -22,9 +50,35 @@ module Scenic
     private
 
     def dumpable_views_in_database
-      @dumpable_views_in_database ||= Scenic.database.views.reject do |view|
+      return @ordered_dumpable_views_in_database if @ordered_dumpable_views_in_database
+
+      existing_views = Scenic.database.views.reject do |view|
         ignored?(view.name)
       end
+
+      @ordered_dumpable_views_in_database = tsorted_views(existing_views.map(&:name)).map do |view_name|
+        existing_views.find { |ev| ev.name == view_name }
+      end.compact
+    end
+
+    # When dumping the views, their order must be topologically sorted to take into account dependencies
+    def tsorted_views(views_names)
+      views_hash = TSortableHash.new
+
+      ::Scenic.database.execute(DEPENDENT_SQL).each do |relation|
+        source_v = relation["source_table"]
+        dependent = relation["dependent_view"]
+        views_hash[dependent] ||= []
+        views_hash[source_v] ||= []
+        views_hash[dependent] << source_v
+        views_names.delete(source_v)
+        views_names.delete(dependent)
+      end
+
+      # after dependencies, there might be some views left that don't have any dependencies
+      views_names.sort.each { |v| views_hash[v] = [] }
+
+      views_hash.tsort
     end
 
     unless ActiveRecord::SchemaDumper.private_instance_methods(false).include?(:ignored?)

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -7,21 +7,21 @@ class SearchInAHaystack < ActiveRecord::Base
 end
 
 describe Scenic::SchemaDumper, :db do
-  let(:connection) { Search.connection }
+  let(:conn) { Search.connection }
   let(:output) do
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(connection, stream)
+    ActiveRecord::SchemaDumper.dump(conn, stream)
     stream.string
   end
 
   it "dumps a create_view for a view in the database" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    connection.create_view :searches, sql_definition: view_definition
+    conn.create_view :searches, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches", sql_definition: <<-SQL'
     expect(output).to include view_definition
 
-    connection.drop_view :searches
+    conn.drop_view :searches
 
     silence_stream(STDOUT) { eval(output) }
 
@@ -30,7 +30,8 @@ describe Scenic::SchemaDumper, :db do
 
   it "dumps a create_view for a materialized view in the database" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    connection.create_view :searches, materialized: true, sql_definition: view_definition
+    conn.create_view :searches,
+      materialized: true, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches", materialized: true, sql_definition: <<-SQL'
     expect(output).to include view_definition
@@ -39,18 +40,18 @@ describe Scenic::SchemaDumper, :db do
   context "with views in non public schemas" do
     it "dumps a create_view including namespace for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
-      connection.create_view :"scenic.searches", sql_definition: view_definition
+      conn.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
+      conn.create_view :"scenic.searches", sql_definition: view_definition
 
       expect(output).to include 'create_view "scenic.searches",'
 
-      connection.drop_view :'scenic.searches'
+      conn.drop_view :'scenic.searches'
     end
   end
 
   it "ignores tables internal to Rails" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    connection.create_view :searches, sql_definition: view_definition
+    conn.create_view :searches, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches"'
     expect(output).not_to include "ar_internal_metadata"
@@ -60,12 +61,13 @@ describe Scenic::SchemaDumper, :db do
   context "with views using unexpected characters in name" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      connection.create_view '"search in a haystack"', sql_definition: view_definition
+      conn.create_view '"search in a haystack"',
+        sql_definition: view_definition
 
       expect(output).to include 'create_view "\"search in a haystack\"",'
       expect(output).to include view_definition
 
-      connection.drop_view :'"search in a haystack"'
+      conn.drop_view :'"search in a haystack"'
 
       silence_stream(STDOUT) { eval(output) }
 
@@ -76,16 +78,16 @@ describe Scenic::SchemaDumper, :db do
   context "with views using unexpected characters, name including namespace" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      connection.execute(
+      conn.execute(
         "CREATE SCHEMA scenic; SET search_path TO scenic, public",
       )
-      connection.create_view 'scenic."search in a haystack"',
+      conn.create_view 'scenic."search in a haystack"',
         sql_definition: view_definition
 
       expect(output).to include 'create_view "scenic.\"search in a haystack\"",'
       expect(output).to include view_definition
 
-      connection.drop_view :'scenic."search in a haystack"'
+      conn.drop_view :'scenic."search in a haystack"'
 
       silence_stream(STDOUT) { eval(output) }
 
@@ -102,12 +104,12 @@ describe Scenic::SchemaDumper, :db do
 
     context "without dependencies" do
       it "sorts views without dependencies" do
-        connection.create_view "cucumber_needles",
-                               sql_definition: "SELECT 'kukumbas'::text as needle"
-        connection.create_view "vip_needles",
-                               sql_definition: "SELECT 'vip'::text as needle"
-        connection.create_view "none_needles",
-                               sql_definition: "SELECT 'none_needles'::text as needle"
+        conn.create_view "cucumber_needles",
+          sql_definition: "SELECT 'kukumbas'::text as needle"
+        conn.create_view "vip_needles",
+          sql_definition: "SELECT 'vip'::text as needle"
+        conn.create_view "none_needles",
+          sql_definition: "SELECT 'none_needles'::text as needle"
 
         # Same here, no dependencies among existing views, all views are sorted
         sorted_views = %w[cucumber_needles vip_needles none_needles].sort
@@ -118,47 +120,53 @@ describe Scenic::SchemaDumper, :db do
 
     context "with dependencies" do
       it "sorts according to dependencies" do
-        connection.create_table(:tasks) { |t| t.integer :performer_id }
-        connection.create_table(:notes) { |t| t.text :title; t.integer :author_id }
-        connection.create_table(:users) { |t| t.text :nickname }
-        connection.create_table(:roles) { |t| t.text :name; t.integer :user_id }
+        conn.create_table(:tasks) { |t| t.integer :performer_id }
+        conn.create_table(:notes) do |t|
+          t.text :title
+          t.integer :author_id
+        end
+        conn.create_table(:users) { |t| t.text :nickname }
+        conn.create_table(:roles) do |t|
+          t.text :name
+          t.integer :user_id
+        end
 
-        connection.create_view "recent_tasks",
-                               sql_definition: <<-SQL
-                                 SELECT id, performer_id from tasks where id > 42
-                               SQL
-        connection.create_view "old_roles",
-                               sql_definition: <<-SQL
-                                SELECT id, name from roles where id > 56
-                               SQL
-        connection.create_view "nirvana_notes",
-                               sql_definition: <<-SQL
-                                SELECT notes.id, notes.title, notes.author_id, old_roles.name FROM notes
-                                JOIN old_roles ON notes.author_id = old_roles.id
-                               SQL
-        connection.create_view "angry_zombies",
-                               sql_definition: <<-SQL
-                                 SELECT users.nickname, recent_tasks.id as task_id, nirvana_notes.title as talk FROM users
-                                 JOIN roles ON roles.user_id = users.id
-                                 JOIN nirvana_notes ON nirvana_notes.author_id = roles.id
-                                 JOIN recent_tasks ON recent_tasks.performer_id = roles.id
-                               SQL
-        connection.create_view "doctor_zombies",
-                               sql_definition: <<-SQL
-                                SELECT id FROM old_roles WHERE name LIKE '%Dr%'
-                               SQL
-        connection.create_view "xenomorphs",
-                               sql_definition: <<-SQL
-                                SELECT id, name FROM roles WHERE name = 'xeno'
-                               SQL
-        connection.create_view "important_messages",
-                               sql_definition: <<-SQL
-                                SELECT id, title FROM notes WHERE title LIKE '%NSFW%'
-                               SQL
+        conn.create_view "recent_tasks",
+          sql_definition: <<-SQL
+            SELECT id, performer_id from tasks where id > 42
+          SQL
+        conn.create_view "old_roles",
+          sql_definition: <<-SQL
+           SELECT id, name from roles where id > 56
+          SQL
+        conn.create_view "nirvana_notes",
+          sql_definition: <<-SQL
+           SELECT notes.id, notes.title, notes.author_id, old_roles.name FROM notes
+           JOIN old_roles ON notes.author_id = old_roles.id
+          SQL
+        conn.create_view "angry_zombies",
+          sql_definition: <<-SQL
+            SELECT users.nickname, recent_tasks.id as task_id, nirvana_notes.title as talk FROM users
+            JOIN roles ON roles.user_id = users.id
+            JOIN nirvana_notes ON nirvana_notes.author_id = roles.id
+            JOIN recent_tasks ON recent_tasks.performer_id = roles.id
+          SQL
+        conn.create_view "doctor_zombies",
+          sql_definition: <<-SQL
+           SELECT id FROM old_roles WHERE name LIKE '%Dr%'
+          SQL
+        conn.create_view "xenomorphs",
+          sql_definition: <<-SQL
+           SELECT id, name FROM roles WHERE name = 'xeno'
+          SQL
+        conn.create_view "important_messages",
+          sql_definition: <<-SQL
+            SELECT id, title FROM notes WHERE title LIKE '%NSFW%'
+          SQL
 
         # Converted with https://github.com/ggerganov/dot-to-ascii
         # digraph {
-        #   rankdir = "RL";
+        #   rankdir = "BT";
         #   xenomorphs;
         #   important_messages;
         #   doctor_zombies -> old_roles;
@@ -167,22 +175,36 @@ describe Scenic::SchemaDumper, :db do
         #   angry_zombies -> recent_tasks;
         # }
         #
-        #                                                                +--------------------+
-        #                                                                |    recent_tasks    |
-        #                                                                +--------------------+
-        #                                                                  ^
-        #                                                                  |
-        #                                                                  |
-        # +----------------+     +-----------+     +---------------+     +--------------------+
-        # | doctor_zombies | --> | old_roles | <-- | nirvana_notes | <-- |    angry_zombies   |
-        # +----------------+     +-----------+     +---------------+     +--------------------+
-        #                                                                +--------------------+
-        #                                                                | important_messages |
-        #                                                                +--------------------+
-        #                                                                +--------------------+
-        #                                                                |     xenomorphs     |
-        #                                                                +--------------------+
-        expect(views).to eq(%w[old_roles nirvana_notes recent_tasks angry_zombies doctor_zombies important_messages xenomorphs])
+        # +--------------------+
+        # |   doctor_zombies   |
+        # +--------------------+
+        #   |
+        #   |
+        #   v
+        # +--------------------+
+        # |     old_roles      |
+        # +--------------------+
+        #   ^
+        #   |
+        #   |
+        # +--------------------+
+        # |   nirvana_notes    |
+        # +--------------------+
+        #   ^
+        #   |
+        #   |
+        # +--------------------+     +--------------+
+        # |   angry_zombies    | --> | recent_tasks |
+        # +--------------------+     +--------------+
+        # +--------------------+
+        # | important_messages |
+        # +--------------------+
+        # +--------------------+
+        # |     xenomorphs     |
+        # +--------------------+
+        expect(views).to eq(%w[old_roles nirvana_notes recent_tasks
+                               angry_zombies doctor_zombies
+                               important_messages xenomorphs])
       end
     end
   end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -7,19 +7,21 @@ class SearchInAHaystack < ActiveRecord::Base
 end
 
 describe Scenic::SchemaDumper, :db do
+  let(:connection) { Search.connection }
+  let(:output) do
+    stream = StringIO.new
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+    stream.string
+  end
+
   it "dumps a create_view for a view in the database" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    Search.connection.create_view :searches, sql_definition: view_definition
-    stream = StringIO.new
-
-    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-    output = stream.string
+    connection.create_view :searches, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches", sql_definition: <<-SQL'
     expect(output).to include view_definition
 
-    Search.connection.drop_view :searches
+    connection.drop_view :searches
 
     silence_stream(STDOUT) { eval(output) }
 
@@ -28,12 +30,7 @@ describe Scenic::SchemaDumper, :db do
 
   it "dumps a create_view for a materialized view in the database" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    Search.connection.create_view :searches, materialized: true, sql_definition: view_definition
-    stream = StringIO.new
-
-    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-    output = stream.string
+    connection.create_view :searches, materialized: true, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches", materialized: true, sql_definition: <<-SQL'
     expect(output).to include view_definition
@@ -42,27 +39,18 @@ describe Scenic::SchemaDumper, :db do
   context "with views in non public schemas" do
     it "dumps a create_view including namespace for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      Search.connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
-      Search.connection.create_view :"scenic.searches", sql_definition: view_definition
-      stream = StringIO.new
+      connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
+      connection.create_view :"scenic.searches", sql_definition: view_definition
 
-      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-      output = stream.string
       expect(output).to include 'create_view "scenic.searches",'
 
-      Search.connection.drop_view :'scenic.searches'
+      connection.drop_view :'scenic.searches'
     end
   end
 
   it "ignores tables internal to Rails" do
     view_definition = "SELECT 'needle'::text AS haystack"
-    Search.connection.create_view :searches, sql_definition: view_definition
-    stream = StringIO.new
-
-    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-    output = stream.string
+    connection.create_view :searches, sql_definition: view_definition
 
     expect(output).to include 'create_view "searches"'
     expect(output).not_to include "ar_internal_metadata"
@@ -72,16 +60,12 @@ describe Scenic::SchemaDumper, :db do
   context "with views using unexpected characters in name" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      Search.connection.create_view '"search in a haystack"', sql_definition: view_definition
-      stream = StringIO.new
+      connection.create_view '"search in a haystack"', sql_definition: view_definition
 
-      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-      output = stream.string
       expect(output).to include 'create_view "\"search in a haystack\"",'
       expect(output).to include view_definition
 
-      Search.connection.drop_view :'"search in a haystack"'
+      connection.drop_view :'"search in a haystack"'
 
       silence_stream(STDOUT) { eval(output) }
 
@@ -92,24 +76,114 @@ describe Scenic::SchemaDumper, :db do
   context "with views using unexpected characters, name including namespace" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      Search.connection.execute(
+      connection.execute(
         "CREATE SCHEMA scenic; SET search_path TO scenic, public",
       )
-      Search.connection.create_view 'scenic."search in a haystack"',
+      connection.create_view 'scenic."search in a haystack"',
         sql_definition: view_definition
-      stream = StringIO.new
 
-      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-
-      output = stream.string
       expect(output).to include 'create_view "scenic.\"search in a haystack\"",'
       expect(output).to include view_definition
 
-      Search.connection.drop_view :'scenic."search in a haystack"'
+      connection.drop_view :'scenic."search in a haystack"'
 
       silence_stream(STDOUT) { eval(output) }
 
       expect(SearchInAHaystack.take.haystack).to eq "needle"
+    end
+  end
+
+  context "with viewes ordered by name" do
+    let(:views) do
+      output.lines.grep(/create_view/).map do |view_line|
+        view_line.match('create_view "(?<name>.*)"')[:name]
+      end
+    end
+
+    context "without dependencies" do
+      it "sorts views without dependencies" do
+        connection.create_view "cucumber_needles",
+                               sql_definition: "SELECT 'kukumbas'::text as needle"
+        connection.create_view "vip_needles",
+                               sql_definition: "SELECT 'vip'::text as needle"
+        connection.create_view "none_needles",
+                               sql_definition: "SELECT 'none_needles'::text as needle"
+
+        # Same here, no dependencies among existing views, all views are sorted
+        sorted_views = %w[cucumber_needles vip_needles none_needles].sort
+
+        expect(views).to eq(sorted_views)
+      end
+    end
+
+    context "with dependencies" do
+      it "sorts according to dependencies" do
+        connection.create_table(:tasks) { |t| t.integer :performer_id }
+        connection.create_table(:notes) { |t| t.text :title; t.integer :author_id }
+        connection.create_table(:users) { |t| t.text :nickname }
+        connection.create_table(:roles) { |t| t.text :name; t.integer :user_id }
+
+        connection.create_view "recent_tasks",
+                               sql_definition: <<-SQL
+                                 SELECT id, performer_id from tasks where id > 42
+                               SQL
+        connection.create_view "old_roles",
+                               sql_definition: <<-SQL
+                                SELECT id, name from roles where id > 56
+                               SQL
+        connection.create_view "nirvana_notes",
+                               sql_definition: <<-SQL
+                                SELECT notes.id, notes.title, notes.author_id, old_roles.name FROM notes
+                                JOIN old_roles ON notes.author_id = old_roles.id
+                               SQL
+        connection.create_view "angry_zombies",
+                               sql_definition: <<-SQL
+                                 SELECT users.nickname, recent_tasks.id as task_id, nirvana_notes.title as talk FROM users
+                                 JOIN roles ON roles.user_id = users.id
+                                 JOIN nirvana_notes ON nirvana_notes.author_id = roles.id
+                                 JOIN recent_tasks ON recent_tasks.performer_id = roles.id
+                               SQL
+        connection.create_view "doctor_zombies",
+                               sql_definition: <<-SQL
+                                SELECT id FROM old_roles WHERE name LIKE '%Dr%'
+                               SQL
+        connection.create_view "xenomorphs",
+                               sql_definition: <<-SQL
+                                SELECT id, name FROM roles WHERE name = 'xeno'
+                               SQL
+        connection.create_view "important_messages",
+                               sql_definition: <<-SQL
+                                SELECT id, title FROM notes WHERE title LIKE '%NSFW%'
+                               SQL
+
+        # Converted with https://github.com/ggerganov/dot-to-ascii
+        # digraph {
+        #   rankdir = "RL";
+        #   xenomorphs;
+        #   important_messages;
+        #   doctor_zombies -> old_roles;
+        #   nirvana_notes -> old_roles;
+        #   angry_zombies -> nirvana_notes;
+        #   angry_zombies -> recent_tasks;
+        # }
+        #
+        #                                                                +--------------------+
+        #                                                                |    recent_tasks    |
+        #                                                                +--------------------+
+        #                                                                  ^
+        #                                                                  |
+        #                                                                  |
+        # +----------------+     +-----------+     +---------------+     +--------------------+
+        # | doctor_zombies | --> | old_roles | <-- | nirvana_notes | <-- |    angry_zombies   |
+        # +----------------+     +-----------+     +---------------+     +--------------------+
+        #                                                                +--------------------+
+        #                                                                | important_messages |
+        #                                                                +--------------------+
+        #                                                                +--------------------+
+        #                                                                |     xenomorphs     |
+        #                                                                +--------------------+
+        expect(views).to eq(%w[old_roles nirvana_notes recent_tasks angry_zombies doctor_zombies important_messages xenomorphs])
+      end
     end
   end
 end


### PR DESCRIPTION
This introduces topological sorting (https://ruby-doc.org/stdlib-2.6.8/libdoc/tsort/rdoc/TSort.html#method-i-tsort) for views in dumps which will sort views alphabetically and in case of dependencies between views will use a topological sorting. 
That provides a consistent views ordering in database dumps and prevents of having occasional diffs in schema dumps.

Based on discussion here https://github.com/scenic-views/scenic/issues/263 and code samples https://github.com/scenic-views/scenic/issues/263#issuecomment-679167557 and https://github.com/scenic-views/scenic/issues/263#issuecomment-875009521