### PR TITLE
Fix issue with keyword arguments under Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7"]
+        ruby: ["2.7", "3.0"]
         rails: ["6.0", "6.1", "master"]
         continue-on-error: [false]
 

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -6,18 +6,22 @@ module Scenic
     def create_view(*args)
       record(:create_view, args)
     end
+    ruby2_keywords :create_view if respond_to?(:ruby2_keywords, true)
 
     def drop_view(*args)
       record(:drop_view, args)
     end
+    ruby2_keywords :drop_view if respond_to?(:ruby2_keywords, true)
 
     def update_view(*args)
       record(:update_view, args)
     end
+    ruby2_keywords :update_view if respond_to?(:ruby2_keywords, true)
 
     def replace_view(*args)
       record(:replace_view, args)
     end
+    ruby2_keywords :replace_view if respond_to?(:ruby2_keywords, true)
 
     def invert_create_view(args)
       drop_view_args = StatementArguments.new(args).remove_version.to_a

--- a/lib/scenic/command_recorder/statement_arguments.rb
+++ b/lib/scenic/command_recorder/statement_arguments.rb
@@ -36,15 +36,25 @@ module Scenic
         @options ||= @args[1] || {}
       end
 
-      def options_for_revert
-        options.clone.tap do |revert_options|
-          revert_options[:version] = revert_to_version
-          revert_options.delete(:revert_to_version)
+      def keyword_hash(hash)
+        if Hash.respond_to? :ruby2_keywords_hash
+          Hash.ruby2_keywords_hash(hash)
+        else
+          hash
         end
       end
 
+      def options_for_revert
+        opts = options.clone.tap do |revert_options|
+          revert_options[:version] = revert_to_version
+          revert_options.delete(:revert_to_version)
+        end
+
+        keyword_hash(opts)
+      end
+
       def options_without_version
-        options.except(:version)
+        keyword_hash(options.except(:version))
       end
     end
   end


### PR DESCRIPTION
Ruby 3 changed the handling of keyword arguments in a way that broke our
liberal handling of arguments in the command recorder. Using
`ruby2_keywords` helps us fix this while maintaining compatibility with
older (pre 2.7) versions of Ruby.

In the next major version of Scenic, we should drop support for rubies
older than either 2.7 or 3.0 to avoid carrying this fix forward.

Fixes #331. For more context on why this is the solution, see:

* https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
* https://github.com/rails/rails/issues/42653