### PR TITLE
Add Rails 7 to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0"]
-        rails: ["6.0", "6.1", "master"]
+        rails: ["6.1", "7.0", "master"]
         continue-on-error: [false]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rails 7 was officially released last night. This change adds it to our
build matrix. I've also dropped 6.0.x from the matrix based on the fact
that it's been demoted to "severe security issues" maintenance mode per
the Rails [maintenance policy](https://github.com/rails/rails/blob/v7.0.0/guides/source/maintenance_policy.md). This also helps us keep our total build reasonable.