### PR TITLE
Add devcontainer configuration for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG VARIANT=2-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
+
+ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
+ENV POSTGRES_USER="postgres"
+ENV POSTGRES_PASSWORD="postgres"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Scenic Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "settings": { },
+  "extensions": ["rebornix.Ruby"],
+  "postCreateCommand": "bin/setup",
+  "remoteUser": "vscode",
+  "features": { "github-cli": "latest" }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        VARIANT: "3"
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    network_mode: service:db
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+volumes:
+  postgres-data: null

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -4,7 +4,7 @@ development: &default
   encoding: unicode
   host: localhost
   pool: 5
-  <% if ENV.fetch("GITHUB_ACTIONS", false) %>
+  <% if ENV.fetch("GITHUB_ACTIONS", false) || ENV.fetch("CODESPACES", false) %>
   username: <%= ENV.fetch("POSTGRES_USER") %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
   <% end %>


### PR DESCRIPTION
This configuration allows Scenic development to be done via Codespaces
for anyone with access to that feature on GitHub. Creating a Codespace
in this project will drop you into an environment ready to run `rake`
and get a fully passing test suite.

I personally do this using the `gh` cli, connecting via SSH, but one
could also connect via VSCode or the web.

Either way, I'm in a fully working environment within 1-2 minutes, which
I find helpful when I've stepped away from development work for a bit
and can't be bothered to figure out my local environment again.

I believe this same configuration should be usable locally for folks who
want to use Docker (see #319), but that is less interesting to me
personally.