### PR TITLE
Fix serialization of views with backslashes

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -46,9 +46,13 @@ module Scenic
 
       <<-DEFINITION
   create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
-    #{definition.indent(2)}
+    #{escaped_definition.indent(2)}
   SQL
       DEFINITION
+    end
+
+    def escaped_definition
+      definition.gsub("\\", "\\\\\\")
     end
   end
 end


### PR DESCRIPTION
Views that contain backslashed (e.g. those that use regular expressions)
were not being properly serialized by the schema dumper. Escaping the
`\` characters in the definition allows them to appear correctly in the
string generated by the Ruby heredoc.