### PR TITLE
Exclude pg_stat_statements_info

### DIFF
--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -34,6 +34,7 @@ module Scenic
             WHERE
               c.relkind IN ('m', 'v')
               AND c.relname NOT IN (SELECT extname FROM pg_extension)
+              AND c.relname != 'pg_stat_statements_info'
               AND n.nspname = ANY (current_schemas(false))
             ORDER BY c.oid
           SQL

--- a/spec/dummy/db/migrate/20220112154220_add_pg_stat_statements_extension.rb
+++ b/spec/dummy/db/migrate/20220112154220_add_pg_stat_statements_extension.rb
@@ -1,0 +1,5 @@
+class AddPgStatStatementsExtension < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pg_stat_statements'
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,0 +1,19 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_01_12_154220) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
+  enable_extension "plpgsql"
+
+end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -95,7 +95,7 @@ describe Scenic::SchemaDumper, :db do
     output = stream.string
 
     expect(output).to include 'create_view "searches"'
-    expect(output).not_to include "ar_internal_metadata"
+    expect(output).not_to include "pg_stat_statements_info"
     expect(output).not_to include "schema_migrations"
   end
 


### PR DESCRIPTION
Postgres 14 [introduced] an internal view `pg_stat_statements_info`, which
we need to exclude from our dumper because including it causes loading
the schema to fail:

[introduced]: <https://www.postgresql.org/docs/14/release-14.html#:~:text=Add%20pg_stat_statements_info%20system%20view%20to%20show%20pg_stat_statements%20activity> "Postgres 14 release notes stating 'Add pg_stat_statements_info system view to show pg_stat_statements activity'"

    PG::DuplicateTable: ERROR:  relation "pg_stat_statements_info" already exists

To test this, enable pg_stat_statements in the dummy database. This is a
reasonable addition as the majority of rails apps are using this
extension and it's cleaner and less error-prone than adding a fake view
of the same name in a specific test for this case.

To support this view, we're currently specifically excluding it in the
query used in the Postgres adapter to load views. Rather then excluding
it by name, we could do an extension of our current exclusion for
extension-owned views, `AND c.relname NOT IN (SELECT extname FROM
pg_extension)`
 by excluding any views with an extension name included
rather than exact matches. I'm not convinced that this is more robust
than excluding exact names has been shown to be by this bug.

Fixes #348