### PR TITLE
Renamed migrations to end in `version{number}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here's where Scenic really shines. Run that same view generator once more:
 ```sh
 $ rails generate scenic:view search_results
       create  db/views/search_results_v02.sql
-      create  db/migrate/[TIMESTAMP]_update_search_results_to_version_2.rb
+      create  db/migrate/[TIMESTAMP]_update_search_results_to_version2.rb
 ```
 
 Scenic detected that we already had an existing `search_results` view at version
@@ -102,7 +102,7 @@ To start replacing a view run the generator like for a regular change:
 ```sh
 $ rails generate scenic:view search_results
       create  db/views/search_results_v02.sql
-      create  db/migrate/[TIMESTAMP]_update_search_results_to_version_2.rb
+      create  db/migrate/[TIMESTAMP]_update_search_results_to_version2.rb
 ```
 
 Now, edit the migration. It should look something like:

--- a/lib/generators/scenic/view/USAGE
+++ b/lib/generators/scenic/view/USAGE
@@ -17,4 +17,4 @@ Examples:
     rails generate scenic:view searches
 
       create: db/views/searches_v02.sql
-      create: db/migrate/20140804191158_update_searches_to_version_2.rb
+      create: db/migrate/20140804191158_update_searches_to_version2.rb

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -33,7 +33,7 @@ module Scenic
         else
           migration_template(
             "db/migrate/update_view.erb",
-            "db/migrate/update_#{plural_file_name}_to_version_#{version}.rb",
+            "db/migrate/update_#{plural_file_name}_to_version#{version}.rb",
           )
         end
       end

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -14,7 +14,7 @@ describe Scenic::Generators::ViewGenerator, :generator do
 
   it "updates an existing view" do
     with_view_definition("searches", 1, "hello") do
-      migration = file("db/migrate/update_searches_to_version_2.rb")
+      migration = file("db/migrate/update_searches_to_version2.rb")
       view_definition = file("db/views/searches_v02.sql")
       allow(Dir).to receive(:entries).and_return(["searches_v01.sql"])
 
@@ -31,7 +31,7 @@ describe Scenic::Generators::ViewGenerator, :generator do
 
       run_generator ["aired_episode", "--materialized"]
       migration = migration_file(
-        "db/migrate/update_aired_episodes_to_version_2.rb",
+        "db/migrate/update_aired_episodes_to_version2.rb",
       )
       expect(migration).to contain "materialized: true"
     end


### PR DESCRIPTION
This is an update to change the generated migration filenames so that they end in `version{number}` rather than `version_{number}`. 

This is to resolve the new `Rails/MigrationClassName` rubocop cop issue raised in https://github.com/scenic-views/scenic/issues/355.