### PR TITLE
Fix ERB deprecation warning

### DIFF
--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -37,10 +37,19 @@ module Scenic
         source  = File.expand_path(find_in_source_paths(source.to_s))
         context = instance_eval("binding", __FILE__, __LINE__)
 
-        erb = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
-          ERB.new(::File.binread(source), trim_mode: "-", eoutvar: "@output_buffer")
+        if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          erb = ERB.new(
+            ::File.binread(source),
+            trim_mode: "-",
+            eoutvar: "@output_buffer",
+          )
         else
-          ERB.new(::File.binread(source), nil, "-", "@output_buffer")
+          erb = ERB.new(
+            ::File.binread(source),
+            nil,
+            "-",
+            "@output_buffer",
+          )
         end
 
         erb.result(context)

--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -36,12 +36,14 @@ module Scenic
       def evaluate_template(source)
         source  = File.expand_path(find_in_source_paths(source.to_s))
         context = instance_eval("binding", __FILE__, __LINE__)
-        ERB.new(
-          ::File.binread(source),
-          nil,
-          "-",
-          "@output_buffer",
-        ).result(context)
+
+        erb = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(::File.binread(source), trim_mode: "-", eoutvar: "@output_buffer")
+        else
+          ERB.new(::File.binread(source), nil, "-", "@output_buffer")
+        end
+
+        erb.result(context)
       end
 
       def generating?


### PR DESCRIPTION
example warning:
```
lib/generators/scenic/model/model_generator.rb:39: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
```

followed Ruby standard library style to make distinction on ERB version check:
https://github.com/ruby/ruby/commit/3406c5d