### PR TITLE
Add flag --replace_view to migration generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,30 +92,18 @@ a new version of it.
 This is not desirable when you have complicated hierarchies of views, especially
 when some of those views may be materialized and take a long time to recreate.
 
-You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement.
-
-See Postgres documentation on how this works:
-http://www.postgresql.org/docs/current/static/sql-createview.html
-
-To start replacing a view run the generator like for a regular change:
+You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement instead by adding the `--replace_view` option to the generate command:
 
 ```sh
-$ rails generate scenic:view search_results
+$ rails generate scenic:view search_results --replace_view
       create  db/views/search_results_v02.sql
       create  db/migrate/[TIMESTAMP]_update_search_results_to_version_2.rb
 ```
 
-Now, edit the migration. It should look something like:
+See Postgres documentation on how this works:
+http://www.postgresql.org/docs/current/static/sql-createview.html
 
-```ruby
-class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
-  def change
-    update_view :search_results, version: 2, revert_to_version: 1
-  end
-end
-```
-
-Update it to use replace view:
+The migration will look something like this:
 
 ```ruby
 class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
@@ -125,7 +113,7 @@ class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
 end
 ```
 
-Now you can run the migration like normal.
+You can run the migration and the view will be replaced instead.
 
 ## Can I use this view to back a model?
 

--- a/lib/generators/scenic/materializable.rb
+++ b/lib/generators/scenic/materializable.rb
@@ -15,12 +15,21 @@ module Scenic
           required: false,
           desc: "Adds WITH NO DATA when materialized view creates/updates",
           default: false
+        class_option :replace_view,
+          type: :boolean,
+          required: false,
+          desc: "Uses replace_view instead of update_view",
+          default: false
       end
 
       private
 
       def materialized?
         options[:materialized]
+      end
+
+      def replace_view?
+        options[:replace_view]
       end
 
       def no_data?

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -1,12 +1,13 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
+  <% method_name = replace_view? ? 'replace_view' : 'update_view' %>
   <%- if materialized? -%>
-    update_view <%= formatted_plural_name %>,
+    <%= method_name %> <%= formatted_plural_name %>,
       version: <%= version %>,
       revert_to_version: <%= previous_version %>,
       materialized: <%= no_data? ? "{ no_data: true }" : true %>
   <%- else -%>
-    update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
+    <%= method_name %> <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   <%- end -%>
   end
 end

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -37,6 +37,18 @@ describe Scenic::Generators::ViewGenerator, :generator do
     end
   end
 
+  it "uses 'replace_view' instead of 'update_view' if replace flag is set" do
+    with_view_definition("aired_episodes", 1, "hello") do
+      allow(Dir).to receive(:entries).and_return(["aired_episodes_v01.sql"])
+
+      run_generator ["aired_episode", "--replace_view"]
+      migration = migration_file(
+        "db/migrate/update_aired_episodes_to_version_2.rb",
+      )
+      expect(migration).to contain "replace_view"
+    end
+  end
+
   context "for views created in a schema other than 'public'" do
     it "creates a view definition" do
       view_definition = file("db/views/non_public_searches_v01.sql")


### PR DESCRIPTION
The previous method to achieve this was by running the generator and editing the migration file. This makes this workflow simpler as well as simplifying the documentation of this feature.

I added a spec and updated the README. Let me know if I need to do anything else.