### PR TITLE
Rename `--replace_view` flag to `--replace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ a new version of it.
 This is not desirable when you have complicated hierarchies of views, especially
 when some of those views may be materialized and take a long time to recreate.
 
-You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement instead by adding the `--replace_view` option to the generate command:
+You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement
+instead by adding the `--replace` option to the generate command:
 
 ```sh
-$ rails generate scenic:view search_results --replace_view
+$ rails generate scenic:view search_results --replace
       create  db/views/search_results_v02.sql
       create  db/migrate/[TIMESTAMP]_update_search_results_to_version_2.rb
 ```

--- a/lib/generators/scenic/materializable.rb
+++ b/lib/generators/scenic/materializable.rb
@@ -15,7 +15,7 @@ module Scenic
           required: false,
           desc: "Adds WITH NO DATA when materialized view creates/updates",
           default: false
-        class_option :replace_view,
+        class_option :replace,
           type: :boolean,
           required: false,
           desc: "Uses replace_view instead of update_view",
@@ -29,7 +29,7 @@ module Scenic
       end
 
       def replace_view?
-        options[:replace_view]
+        options[:replace]
       end
 
       def no_data?

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -41,7 +41,7 @@ describe Scenic::Generators::ViewGenerator, :generator do
     with_view_definition("aired_episodes", 1, "hello") do
       allow(Dir).to receive(:entries).and_return(["aired_episodes_v01.sql"])
 
-      run_generator ["aired_episode", "--replace_view"]
+      run_generator ["aired_episode", "--replace"]
       migration = migration_file(
         "db/migrate/update_aired_episodes_to_version_2.rb",
       )


### PR DESCRIPTION
This flag was introduced in #368 but hasn't been in a release yet. I was
writing up the next release's changelog and I wasn't thrilled with
having an underscore in a CLI flag.

There's something to be said for `--replace_view` matching the schema
method that the generated method invokes but I think `--replace` is
still better.
