### PR TITLE
Remove rails master from our test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1"]
-        rails: ["6.1", "7.0", "master"]
+        rails: ["6.1", "7.0"]
         continue-on-error: [false]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're not an active enough project to keep up with master as part of a
required build task. I don't want to turn off any contributors who see a
red build against an unreleased version of Rails.

I think we could rework these as a separate workflow that reports status
appropriately but is not required, but I'll leave that for another day.
