### PR TITLE
ERB interpolation in definition file, and `version: :latest` as an option

### DIFF
--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -7,7 +7,7 @@ module Scenic
     end
 
     def to_sql
-      File.read(full_path).tap do |content|
+      ERB.new(File.read(full_path)).result.tap do |content|
         if content.empty?
           raise "Define view query in #{path} before migrating."
         end

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -3,7 +3,7 @@ module Scenic
   class Definition
     def initialize(name, version)
       @name = name.to_s
-      @version = version.to_i
+      @version = version
     end
 
     def to_sql
@@ -23,7 +23,8 @@ module Scenic
     end
 
     def version
-      @version.to_s.rjust(2, "0")
+      @version = latest_version if @version == :latest
+      @version.to_i.to_s.rjust(2, "0")
     end
 
     private
@@ -32,6 +33,11 @@ module Scenic
 
     def filename
       "#{UnaffixedName.for(name).tr('.', '_')}_v#{version}.sql"
+    end
+
+    def latest_version
+      Dir.glob(Rails.root.join('db', 'views', "#{name}*.sql")).sort.last =~ /#{name}_v(\d*).sql/i
+      $1
     end
   end
 end

--- a/lib/scenic/version.rb
+++ b/lib/scenic/version.rb
@@ -1,3 +1,3 @@
 module Scenic
-  VERSION = "1.7.0".freeze
+  VERSION = "1.7.1".freeze
 end

--- a/spec/scenic/definition_spec.rb
+++ b/spec/scenic/definition_spec.rb
@@ -65,6 +65,16 @@ module Scenic
 
         expect(definition.version).to eq "15"
       end
+
+      it "returns latest version" do
+        with_view_definition 'a_versioned_file', 1, "Select 1 from somethings" do
+          with_view_definition 'a_versioned_file', 5, "Select * from somethings" do
+            definition = Definition.new('a_versioned_file', :latest)
+
+            expect(definition.version).to eq "05"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ require "support/generator_spec_setup"
 require "support/view_definition_helpers"
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.order = "random"
   config.include ViewDefinitionHelpers
   config.include RailsConfigurationHelpers


### PR DESCRIPTION
ERB interpolation is helpful when using ruby constants/methods used inside the definition file.
`version: :latest` allows for instructing scenic to use the latest version of the definition found at that commit.  This is useful when we have to drop views due to a dependency on them and having to recreate them afterward.