### PR TITLE
Add fx to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,11 @@ meet your needs:
 Please note that the maintainers of Scenic make no assertions about the
 quality or security of the above adapters.
 
+**Related projects**
+
+- [`fx`](<https://github.com/teoljungberg/fx>) Versioned database functions and
+  triggers for Rails
+
 ## About
 
 Scenic is used by some popular open source Rails apps:


### PR DESCRIPTION
With issues such as #207, #146, #239, and #158. There is a use-case for
mentioning projects that solves the issue of adding support for
functions and triggers to a Rails application.

This PR documents it as a suggestion for users of Scenic, to know where
to look.