### PR TITLE
Remove extra whitespace from generated update migrations

### DIFF
--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
-  <% method_name = replace_view? ? 'replace_view' : 'update_view' %>
+  <%- method_name = replace_view? ? 'replace_view' : 'update_view' -%>
   <%- if materialized? -%>
     <%= method_name %> <%= formatted_plural_name %>,
       version: <%= version %>,


### PR DESCRIPTION
The rails generator adds an annoying newline when creating `update_view` or `replace_view` migrations where the ruby is evaluated. 