### PR TITLE
Add side_by_side mode to update_materialized_view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gemspec
 
 rails_version = ENV.fetch("RAILS_VERSION", "6.1")
 
-if rails_version == "master"
-  rails_constraint = { github: "rails/rails" }
+rails_constraint = if rails_version == "master"
+  {github: "rails/rails"}
 else
-  rails_constraint = "~> #{rails_version}.0"
+  "~> #{rails_version}.0"
 end
 
 gem "rails", rails_constraint

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -163,8 +163,9 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def update_materialized_view(name, sql_definition, no_data: false,
-                                   side_by_side: false)
+      def update_materialized_view(
+        name, sql_definition, no_data: false, side_by_side: false
+      )
         raise_unless_materialized_views_supported
 
         IndexReapplication.new(connection: connection).on(name) do

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -155,15 +155,16 @@ module Scenic
       # @param no_data [Boolean] Default: false. Set to true to create
       #   materialized view without running the associated query. You will need
       #   to perform a non-concurrent refresh to populate with data.
-      # @param side_by_side [Boolean] Default: false. Set to true to create the new
-      #   version under a different name and atomically swap them, limiting downtime
-      #   at the cost of doubling disk usage
+      # @param side_by_side [Boolean] Default: false. Set to true to create the
+      #   new version under a different name and atomically swap them, limiting
+      #   downtime at the cost of doubling disk usage
       #
       # @raise [MaterializedViewsNotSupportedError] if the version of Postgres
       #   in use does not support materialized views.
       #
       # @return [void]
-      def update_materialized_view(name, sql_definition, no_data: false, side_by_side: false)
+      def update_materialized_view(name, sql_definition, no_data: false,
+                                   side_by_side: false)
         raise_unless_materialized_views_supported
 
         IndexReapplication.new(connection: connection).on(name) do
@@ -206,7 +207,8 @@ module Scenic
       # @return [void]
       def rename_materialized_view(name, new_name)
         raise_unless_materialized_views_supported
-        execute "ALTER MATERIALIZED VIEW #{quote_table_name(name)} RENAME TO #{quote_table_name(new_name)};"
+        execute "ALTER MATERIALIZED VIEW #{quote_table_name(name)}"\
+                "RENAME TO #{quote_table_name(new_name)};"
       end
 
       # Refreshes a materialized view from its SQL schema.

--- a/lib/scenic/adapters/postgres/index_reapplication.rb
+++ b/lib/scenic/adapters/postgres/index_reapplication.rb
@@ -35,6 +35,18 @@ module Scenic
           indexes.each(&method(:try_index_create))
         end
 
+        def on_side_by_side(name, new_table_name, temporary_id)
+          indexes = Indexes.new(connection: connection).on(name)
+          indexes.each_with_index do |index, i|
+            old_name = "predrop_index_#{temporary_id}_#{i}"
+            connection.rename_index(name, index.index_name, old_name)
+          end
+          yield
+          indexes.each do |index|
+            try_index_create(index.with_other_object_name(new_table_name))
+          end
+        end
+
         private
 
         attr_reader :connection, :speaker

--- a/lib/scenic/adapters/postgres/indexes.rb
+++ b/lib/scenic/adapters/postgres/indexes.rb
@@ -27,6 +27,7 @@ module Scenic
             SELECT
               t.relname as object_name,
               i.relname as index_name,
+              n.nspname as schema_name,
               pg_get_indexdef(d.indexrelid) AS definition
             FROM pg_class t
             INNER JOIN pg_index d ON t.oid = d.indrelid
@@ -45,6 +46,7 @@ module Scenic
             object_name: result["object_name"],
             index_name: result["index_name"],
             definition: result["definition"],
+            schema_name: result["schema_name"],
           )
         end
       end

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -59,7 +59,7 @@ module Scenic
         object_name: object_name,
         index_name: @index_name,
         schema_name: @schema_name,
-        definition: tweaked_definition
+        definition: tweaked_definition,
       )
     end
   end

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -53,7 +53,7 @@ module Scenic
       unless @definition.start_with? old_prefix
         raise "Unhandled index definition: '#{@definition}' (expected to start with '#{old_prefix}'"
       end
-      tweaked_definition = new_prefix + @definition.slice((old_prefix.size)..)
+      tweaked_definition = new_prefix + @definition.slice((old_prefix.size)..(@definition.size))
       self.class.new(
         object_name: object_name,
         index_name: @index_name,

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -51,9 +51,10 @@ module Scenic
       old_prefix = "#{type} #{@index_name} ON #{@schema_name}.#{@object_name}"
       new_prefix = "#{type} #{@index_name} ON #{@schema_name}.#{object_name}"
       unless @definition.start_with? old_prefix
-        raise "Unhandled index definition: '#{@definition}' (expected to start with '#{old_prefix}'"
+        raise "Unhandled index definition: '#{@definition}'"
       end
-      tweaked_definition = new_prefix + @definition.slice((old_prefix.size)..(@definition.size))
+      suffix = @definition.slice((old_prefix.size)..(@definition.size))
+      tweaked_definition = new_prefix + suffix
       self.class.new(
         object_name: object_name,
         index_name: @index_name,

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -22,15 +22,44 @@ module Scenic
     #   "CREATE INDEX index_users_on_email ON users USING btree (email)"
     attr_reader :definition
 
+    # The schema under which the index is defined
+    # @return [String]
+    attr_reader :schema_name
+
     # Returns a new instance of Index
     #
     # @param object_name [String] The name of the object that has the index
     # @param index_name [String] The name of the index
     # @param definition [String] The SQL statements that defined the index
-    def initialize(object_name:, index_name:, definition:)
+    def initialize(object_name:, index_name:, definition:, schema_name:)
       @object_name = object_name
       @index_name = index_name
       @definition = definition
+      @schema_name = schema_name
+    end
+
+    # Return a new instance of Index with the definition changed to create
+    # the index against a different object name.
+    #
+    # @param object_name [String] The name of the object that has the index
+    def with_other_object_name(object_name)
+      type = if @definition.start_with? "CREATE UNIQUE"
+               "CREATE UNIQUE INDEX"
+             else
+               "CREATE INDEX"
+             end
+      old_prefix = "#{type} #{@index_name} ON #{@schema_name}.#{@object_name}"
+      new_prefix = "#{type} #{@index_name} ON #{@schema_name}.#{object_name}"
+      unless @definition.start_with? old_prefix
+        raise "Unhandled index definition: '#{@definition}' (expected to start with '#{old_prefix}'"
+      end
+      tweaked_definition = new_prefix + @definition.slice((old_prefix.size)..)
+      self.class.new(
+        object_name: object_name,
+        index_name: @index_name,
+        schema_name: @schema_name,
+        definition: tweaked_definition
+      )
     end
   end
 end

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -40,7 +40,7 @@ module Scenic
         Scenic.database.create_materialized_view(
           name,
           sql_definition,
-          no_data: no_data(materialized),
+          no_data: hash_value_or_boolean(materialized, :no_data),
         )
       else
         Scenic.database.create_view(name, sql_definition)
@@ -82,7 +82,8 @@ module Scenic
     #   `rake db rollback`
     # @param materialized [Boolean, Hash] True if updating a materialized view.
     #   Set to { no_data: true } to update materialized view without loading
-    #   data. Defaults to false.
+    #   data. Set to { side_by_side: true} to update materialized view with
+    #   fewer locks but more disk usage. Defaults to false.
     # @return The database response from executing the create statement.
     #
     # @example
@@ -109,7 +110,8 @@ module Scenic
         Scenic.database.update_materialized_view(
           name,
           sql_definition,
-          no_data: no_data(materialized),
+          no_data: hash_value_or_boolean(materialized, :no_data),
+          side_by_side: hash_value_or_boolean(materialized, :side_by_side)
         )
       else
         Scenic.database.update_view(name, sql_definition)
@@ -152,9 +154,9 @@ module Scenic
       Scenic::Definition.new(name, version).to_sql
     end
 
-    def no_data(materialized)
-      if materialized.is_a?(Hash)
-        materialized.fetch(:no_data, false)
+    def hash_value_or_boolean(value, key)
+      if value.is_a? Hash
+        value.fetch(key, false)
       else
         false
       end

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -111,7 +111,7 @@ module Scenic
           name,
           sql_definition,
           no_data: hash_value_or_boolean(materialized, :no_data),
-          side_by_side: hash_value_or_boolean(materialized, :side_by_side)
+          side_by_side: hash_value_or_boolean(materialized, :side_by_side),
         )
       else
         Scenic.database.update_view(name, sql_definition)

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -105,15 +105,15 @@ module Scenic
 
       describe "#rename_materialized_view" do
         it "successfully renames a materialized view" do
-            adapter = Postgres.new
+          adapter = Postgres.new
 
-            adapter.create_materialized_view(
-              "greetings",
-              "SELECT text 'hi' AS greeting",
-            )
-            adapter.rename_materialized_view("greetings", "hellos")
+          adapter.create_materialized_view(
+            "greetings",
+            "SELECT text 'hi' AS greeting",
+          )
+          adapter.rename_materialized_view("greetings", "hellos")
 
-            expect(adapter.views.map(&:name)).to include("hellos")
+          expect(adapter.views.map(&:name)).to include("hellos")
         end
 
         it "raises an exception if the version of PostgreSQL is too old" do

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -103,6 +103,30 @@ module Scenic
         end
       end
 
+      describe "#rename_materialized_view" do
+        it "successfully renames a materialized view" do
+            adapter = Postgres.new
+
+            adapter.create_materialized_view(
+              "greetings",
+              "SELECT text 'hi' AS greeting",
+            )
+            adapter.rename_materialized_view("greetings", "hellos")
+
+            expect(adapter.views.map(&:name)).to include("hellos")
+        end
+
+        it "raises an exception if the version of PostgreSQL is too old" do
+          connection = double("Connection", supports_materialized_views?: false)
+          connectable = double("Connectable", connection: connection)
+          adapter = Postgres.new(connectable)
+          err = Scenic::Adapters::Postgres::MaterializedViewsNotSupportedError
+
+          expect { adapter.rename_materialized_view("greetings", "hellos") }
+            .to raise_error err
+        end
+      end
+
       describe "#refresh_materialized_view" do
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -125,7 +125,7 @@ module Scenic
         connection.update_view(:name, version: 3, materialized: true)
 
         expect(Scenic.database).to have_received(:update_materialized_view)
-          .with(:name, definition.to_sql, no_data: false)
+          .with(:name, definition.to_sql, no_data: false, side_by_side: false)
       end
 
       it "updates the materialized view in the database with NO DATA" do
@@ -141,7 +141,23 @@ module Scenic
         )
 
         expect(Scenic.database).to have_received(:update_materialized_view)
-          .with(:name, definition.to_sql, no_data: true)
+          .with(:name, definition.to_sql, no_data: true, side_by_side: false)
+      end
+
+      it "updates the materialized view in the database with side-by-side mode" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3)
+          .and_return(definition)
+
+        connection.update_view(
+          :name,
+          version: 3,
+          materialized: { side_by_side: true },
+        )
+
+        expect(Scenic.database).to have_received(:update_materialized_view)
+          .with(:name, definition.to_sql, no_data: false, side_by_side: true)
       end
 
       it "raises an error if not supplied a version or sql_defintion" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -144,7 +144,7 @@ module Scenic
           .with(:name, definition.to_sql, no_data: true, side_by_side: false)
       end
 
-      it "updates the materialized view in the database with side-by-side mode" do
+      it "updates the materialized view with side-by-side mode" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
           .with(:name, 3)


### PR DESCRIPTION
This adds a `side_by_side` kwarg to the `update_materialized_view` method, which builds the new view alongside the old one and then atomically swaps them to reduce downtime at the cost of increasing disk usage. It is plumbed through to migrations as a hash value for the `materialized` kwarg of `update_view`.

Fixes scenic-views/scenic#386.