### PR TITLE
Add method to check materialized view population

### DIFF
--- a/lib/generators/scenic/model/templates/model.erb
+++ b/lib/generators/scenic/model/templates/model.erb
@@ -1,3 +1,7 @@
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
   end
+
+  def self.populated?
+    Scenic.database.populated?(table_name)
+  end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -222,6 +222,29 @@ module Scenic
         end
       end
 
+      # True if supplied relation name is populated. Useful for checking the
+      # state of materialized views which may error if created `WITH NO DATA`
+      # and used before they are refreshed. True for all other relation types.
+      #
+      # @param name The name of the relation
+      #
+      # @raise [MaterializedViewsNotSupportedError] if the version of Postgres
+      #   in use does not support materialized views.
+      #
+      # @return [boolean]
+      def populated?(name)
+        raise_unless_materialized_views_supported
+
+        sql = "SELECT relispopulated FROM pg_class WHERE relname = '#{name}'"
+        relations = execute(sql)
+
+        if relations.count.positive?
+          relations.first["relispopulated"].in?(["t", true])
+        else
+          false
+        end
+      end
+
       private
 
       attr_reader :connectable

--- a/spec/generators/scenic/model/model_generator_spec.rb
+++ b/spec/generators/scenic/model/model_generator_spec.rb
@@ -32,5 +32,13 @@ module Scenic::Generators
       expect(model_definition).to contain("self.refresh")
       expect(model_definition).to have_correct_syntax
     end
+
+    it "adds a populated? method to materialized models" do
+      run_generator ["active_user", "--materialized"]
+      model_definition = file("app/models/active_user.rb")
+
+      expect(model_definition).to contain("self.populated?")
+      expect(model_definition).to have_correct_syntax
+    end
   end
 end


### PR DESCRIPTION
REFRESH MATERIALIZED VIEW CONCURRENTLY doesn't work for a view which is not populated, even it has unique index. This method is useful to perform concurrent refresh if it's possible.

Real use case in Rails will be like this:

* Database is loaded from structure.sql to run specs, but the view isn't populated yet so concurrent refresh is not possible. We want to fallback to normal(non-concurrent) refresh in this case.
* After initial population, views are expected to be refreshed concurrently. It's possible because the view is already populated.