### PR TITLE
Strip out any view schema prefix in populated?(name)

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -235,7 +235,9 @@ module Scenic
       def populated?(name)
         raise_unless_materialized_views_supported
 
-        sql = "SELECT relispopulated FROM pg_class WHERE relname = '#{name}'"
+        schemaless_name = name.split(".").last
+
+        sql = "SELECT relispopulated FROM pg_class WHERE relname = '#{schemaless_name}'"
         relations = execute(sql)
 
         if relations.count.positive?

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -229,6 +229,18 @@ module Scenic
           expect(adapter.populated?("greetings")).to be true
         end
 
+        it "strips out the schema from table_name" do
+          adapter = Postgres.new
+
+          ActiveRecord::Base.connection.execute <<-SQL
+            CREATE MATERIALIZED VIEW greetings AS
+            SELECT text 'hi' AS greeting
+            WITH NO DATA
+          SQL
+
+          expect(adapter.populated?("public.greetings")).to be false
+        end
+
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)
           connectable = double("Connectable", connection: connection)


### PR DESCRIPTION
`pg_class` stores `relname` without schema prefix