### PR TITLE
Revert "Test for schema order of non-public-schema views"

### DIFF
--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -69,22 +69,6 @@ describe Scenic::SchemaDumper, :db do
 
       Search.connection.drop_view :"scenic.searches"
     end
-
-    it "sorts dependency order when views exist in a non-public schema" do
-      Search.connection.execute("CREATE SCHEMA IF NOT EXISTS scenic; SET search_path TO public, scenic")
-      Search.connection.execute("CREATE VIEW scenic.apples AS SELECT 1;")
-      Search.connection.execute("CREATE VIEW scenic.bananas AS SELECT 2;")
-      Search.connection.execute("CREATE OR REPLACE VIEW scenic.apples AS SELECT * FROM scenic.bananas;")
-      stream = StringIO.new
-
-      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
-      views = stream.string.lines.grep(/create_view/).map do |view_line|
-        view_line.match('create_view "(?<name>.*)"')[:name]
-      end
-      expect(views).to eq(%w[scenic.bananas scenic.apples])
-
-      Search.connection.execute("DROP SCHEMA IF EXISTS scenic CASCADE; SET search_path TO public")
-    end
   end
 
   it "handles active record table name prefixes and suffixes" do


### PR DESCRIPTION
This reverts commit d0f20521f8257bac256ced806cec46a0e32b2f50. It is failing every build on main. cc @calebhearth @edwardloveall as FYI. See https://github.com/scenic-views/scenic/actions/runs/8391929166/job/23074242841#step:9:34 as an example