### PR TITLE
Explicitly loading active_record prevents an error using sidekiqswarm

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -1,4 +1,5 @@
 require "rails"
+require "active_record"
 
 module Scenic
   # @api private


### PR DESCRIPTION
Explicitly require active_record to prevent loading error using sidekiqswarm:

$> sidekiqswarm
[swarm] Preloading Bundler groups ["default"]
bundler: failed to load command: sidekiqswarm (/Users/pcreux/.rbenv/versions/2.6.6/bin/sidekiqswarm) NameError: uninitialized constant Scenic::SchemaDumper::ActiveRecord
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/scenic-1.5.4/lib/scenic/schema_dumper.rb:30:in `<module:SchemaDumper>'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/scenic-1.5.4/lib/scenic/schema_dumper.rb:5:in `<module:Scenic>'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/scenic-1.5.4/lib/scenic/schema_dumper.rb:3:in `<top (required)>'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/scenic-1.5.4/lib/scenic.rb:6:in `<top (required)>'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `require'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `each'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `block in require'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler.rb:114:in `require'
  /Users/pcreux/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-ent-2.2.0/bin/sidekiqswarm:40:in `<top (required)>'
  /Users/pcreux/.rbenv/versions/2.6.6/bin/sidekiqswarm:23:in `load'
  /Users/pcreux/.rbenv/versions/2.6.6/bin/sidekiqswarm:23:in `<top (required)>'