### PR TITLE
Update CI Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3"]
-        rails: ["7.1", "7.2"]
+        ruby: ["3.4", "3.3"]
+        rails: ["8.0", "7.2"]
         continue-on-error: [false]
         include:
-          - ruby: "head"
-            rails: "7.2"
-            continue-on-error: true
-          - ruby: "3.3"
+          - ruby: "3.4"
             rails: "main"
             continue-on-error: true
           - ruby: "head"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 gemfiles/*.lock
 .DS_Store
 .ruby-version
+.vscode/

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in scenic.gemspec
 gemspec
 
-rails_version = ENV.fetch("RAILS_VERSION", "7.0")
+rails_version = ENV.fetch("RAILS_VERSION", "8.0")
 
 rails_constraint = if rails_version == "main"
   {github: "rails/rails"}

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -11,5 +11,9 @@ module Dummy
     config.cache_classes = true
     config.eager_load = false
     config.active_support.deprecation = :stderr
+
+    if config.active_support.respond_to?(:to_time_preserves_timezone)
+      config.active_support.to_time_preserves_timezone = :zone
+    end
   end
 end


### PR DESCRIPTION
It's time for everyone's favorite game: bump the versions! Ruby 3.4 is
out, and Rails 8 has been shipped for some time. We try to keep our CI
suite testing currently-supported versions of each, but we don't want a
giant matrix that requires many customizations to run successfully
either.

As a result, this commit:

* Adds testing our full matrix with Ruby 3.4
* Drops testing with Ruby 3.1
* Drops testing with Rails 7.1

I think this is a good balance of testing the latest versions of Ruby
and Rails while maintaining some backward compatibility in a manner that
doesn't require a degree in YAML to understand.
