### PR TITLE
Update link to MySQL adapter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ We are aware of the following existing adapter libraries for Scenic which may
 meet your needs:
 
 * [`scenic_sqlite_adapter`](<https://github.com/pdebelak/scenic_sqlite_adapter>)
-* [`scenic-mysql_adapter`](<https://github.com/EmpaticoOrg/scenic-mysql_adapter>)
+* [`scenic-mysql_adapter`](<https://github.com/cainlevy/scenic-mysql_adapter>)
 * [`scenic-sqlserver-adapter`](<https://github.com/ClickMechanic/scenic_sqlserver_adapter>)
 * [`scenic-oracle_adapter`](<https://github.com/cdinger/scenic-oracle_adapter>)
 


### PR DESCRIPTION
The current code maintained by @cainlevy is here:
https://github.com/cainlevy/scenic-mysql_adapter

Latest releases are here:
https://github.com/cainlevy/scenic-mysql_adapter/tags

Corresponding releases on Rubygems.org:
https://rubygems.org/gems/scenic-mysql_adapter