### PR TITLE
Improve formatting of dumped schema

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -15,7 +15,14 @@ module Scenic
 
       dumpable_views_in_database.each do |view|
         stream.puts(view.to_schema)
-        indexes(view.name, stream)
+
+        index_stream = StringIO.new
+        indexes(view.name, index_stream)
+
+        if index_stream.string.present?
+          stream.puts
+          stream.puts(index_stream.string)
+        end
       end
     end
 

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -1,3 +1,5 @@
+require "niceql"
+
 module Scenic
   # The in-memory representation of a view definition.
   #
@@ -46,9 +48,17 @@ module Scenic
 
       <<-DEFINITION
   create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
-    #{escaped_definition.indent(2)}
+  #{formatted_definition.indent(2)}
   SQL
       DEFINITION
+    end
+
+    def formatted_definition
+      colorize = false
+
+      Niceql::Prettifier
+        .prettify_sql(escaped_definition, colorize)
+        .chomp(";")
     end
 
     def escaped_definition

--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 4.0.0"
   spec.add_dependency "railties", ">= 4.0.0"
+  spec.add_dependency "niceql", ">= 0.6.1"
 
   spec.required_ruby_version = ">= 2.3.0"
 end


### PR DESCRIPTION
Over time, our dumped schema formatting has become pretty unreadable.
Way back in 2016, Caleb and I talked about adopting a SQL formatter for
Scenic, but we never found a gem we liked and never took it on
ourselves. Enter: [niceql](https://github.com/alekseyl/niceql).

niceql has zero dependencies of its own, is implemented in a single
(large) file, and has over 1.6 million downloads. It has had no releases
since November 2022 but I think it's safe to consider it complete rather
than abandoned. It's required Ruby version is permissive (`>=
2.5`), so unless there are breaking changes to Ruby basics, I don't
think it will be a problem.

I've tried it on a few basic views of my own and it produces compact,
readable SQL. It's maybe not how I would have formatted things by hand,
but it's better than the format we're getting from Postgres. The most
common formatter for Postgres is `pgFormatter` but as best I can tell
there is no Ruby implementation for it today.

In addition to formatting the SQL, this change also adds a newline
between `create_view` statements and any indexes associated with the
view.

Before these changes:

```ruby
  create_view "searches", materialized: true, sql_definition: <<-SQL
      SELECT posts.content,
      posts.user_id
     FROM posts
  UNION
   SELECT posts.title AS content,
      posts.user_id
     FROM posts
  UNION
   SELECT comments.content,
      comments.user_id
     FROM comments;
  SQL
  add_index "searches", ["content"], name: "index_searches_on_content"
  add_index "searches", ["user_id"], name: "index_searches_on_user_id"

```

After these changes:

```ruby
  create_view "searches", materialized: true, sql_definition: <<-SQL
    SELECT posts.content, posts.user_id
    FROM posts UNION
      SELECT posts.title AS content, posts.user_id
      FROM posts UNION
        SELECT comments.content, comments.user_id
        FROM comments
  SQL

  add_index "searches", ["content"], name: "index_searches_on_content"
  add_index "searches", ["user_id"], name: "index_searches_on_user_id"

```
