### PR TITLE
ensure multi-schema dumping in Rails 8.1 doesn't dump the same objects for all schemas

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -9,6 +9,10 @@ module Scenic
     end
 
     def views(stream)
+      dumpable_views_in_database = Scenic.database.views.reject do |view|
+        ignored?(view.name)
+      end
+
       if dumpable_views_in_database.any?
         stream.puts
       end
@@ -16,14 +20,6 @@ module Scenic
       dumpable_views_in_database.each do |view|
         stream.puts(view.to_schema)
         indexes(view.name, stream)
-      end
-    end
-
-    private
-
-    def dumpable_views_in_database
-      @dumpable_views_in_database ||= Scenic.database.views.reject do |view|
-        ignored?(view.name)
       end
     end
   end


### PR DESCRIPTION
In Rails 8.1, `bin/rails db:schema:dump` now knows how to dump multiple schemas (rails/rails#50020). To ensure we don't dump the same functions / triggers for each schema, we need to stop memoizing `Scenic.database.views`.

This should be fully backwards compatible to previous Rails versions, as we still only call each of those methods once per schema dumping invocation, it just now works if schema dumping is invoked multiple times.