### PR TITLE
Add support for security barrier and invoker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ changelog, see the [commits] for each version via the version links.
 
 [commits]: https://github.com/scenic-views/scenic/commits/master
 
+## [Unreleased]
+
+### Added
+
+- Added support for PostgreSQL view options via `with:` hash parameter. Supports
+  `security_barrier`, `security_invoker`, and `check_option` with an extensible
+  interface for future PostgreSQL options.
+
+### Changed
+
+- **BREAKING**: Custom adapter interface has changed. Adapters must update their
+  method signatures:
+
+  ```ruby
+  # Before (Scenic 1.x):
+  def create_view(name, sql_definition)
+  def update_view(name, sql_definition)
+  def replace_view(name, sql_definition)
+
+  # After (Scenic 2.x):
+  def create_view(name, sql_definition, with: {})
+  def update_view(name, sql_definition, with: {})
+  def replace_view(name, sql_definition, with: {})
+  ```
+
+  Adapter maintainers can use `**_options` to accept and ignore options if their
+  database does not support view options, or implement specific option handling
+  as needed.
+
 ## [1.9.0] - June 30, 2025
 
 [1.9.0]: https://github.com/scenic-views/scenic/compare/v1.8.0...v1.9.0

--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -8,6 +8,7 @@ module Scenic
     # @api private
     class ModelGenerator < Rails::Generators::NamedBase
       include Scenic::Generators::Materializable
+
       source_root File.expand_path("templates", __dir__)
 
       def invoke_rails_model_generator

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -8,6 +8,7 @@ module Scenic
     class ViewGenerator < Rails::Generators::NamedBase
       include Rails::Generators::Migration
       include Scenic::Generators::Materializable
+
       source_root File.expand_path("templates", __dir__)
 
       def create_views_directory

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -59,13 +59,15 @@ module Scenic
       #
       # @param name The name of the view to create
       # @param sql_definition The SQL schema for the view.
-      # @param security_barrier If we should enable security_barrier
-      # @param security_invoker If we should enable security_invoker
+      # @param with [Hash] View options to pass to the WITH clause
+      # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+      # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+      # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
       #
       # @return [void]
-      def create_view(name, sql_definition, security_barrier: false, security_invoker: false)
-        with_statement = build_with_statement(security_barrier, security_invoker)
-        execute "CREATE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
+      def create_view(name, sql_definition, with: {})
+        with_clause = build_with_clause(with)
+        execute "CREATE VIEW #{quote_table_name(name)}#{with_clause} AS #{sql_definition};"
       end
 
       # Updates a view in the database.
@@ -82,13 +84,15 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
-      # @param security_barrier If we should enable security_barrier
-      # @param security_invoker If we should enable security_invoker
+      # @param with [Hash] View options to pass to the WITH clause
+      # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+      # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+      # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
       #
       # @return [void]
-      def update_view(name, sql_definition, security_barrier: false, security_invoker: false)
+      def update_view(name, sql_definition, with: {})
         drop_view(name)
-        create_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
+        create_view(name, sql_definition, with: with)
       end
 
       # Replaces a view in the database using `CREATE OR REPLACE VIEW`.
@@ -110,13 +114,15 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
-      # @param security_barrier If we should enable security_barrier
-      # @param security_invoker If we should enable security_invoker
+      # @param with [Hash] View options to pass to the WITH clause
+      # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+      # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+      # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
       #
       # @return [void]
-      def replace_view(name, sql_definition, security_barrier: false, security_invoker: false)
-        with_statement = build_with_statement(security_barrier, security_invoker)
-        execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
+      def replace_view(name, sql_definition, with: {})
+        with_clause = build_with_clause(with)
+        execute "CREATE OR REPLACE VIEW #{quote_table_name(name)}#{with_clause} AS #{sql_definition};"
       end
 
       # Drops the named view from the database
@@ -308,16 +314,22 @@ module Scenic
         )
       end
 
-      def build_with_statement(security_barrier, security_invoker)
-        if security_invoker && security_barrier
-          return "WITH (security_barrier, security_invoker = true)"
-        elsif security_invoker
-          return "WITH (security_invoker = true)"
-        elsif security_barrier
-          return "WITH (security_barrier)"
+      def build_with_clause(options)
+        return "" if options.empty?
+
+        clauses = options.filter_map do |key, value|
+          next if value == false || value.nil?
+
+          case value
+          when true
+            "#{key} = true"
+          else
+            "#{key} = #{value}"
+          end
         end
 
-        ""
+        return "" if clauses.empty?
+        " WITH (#{clauses.join(", ")})"
       end
     end
   end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -59,10 +59,13 @@ module Scenic
       #
       # @param name The name of the view to create
       # @param sql_definition The SQL schema for the view.
+      # @param security_barrier If we should enable security_barrier
+      # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def create_view(name, sql_definition)
-        execute "CREATE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+      def create_view(name, sql_definition, security_barrier, security_invoker)
+        with_statement = build_with_statement(security_barrier, security_invoker)
+        execute "CREATE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
       end
 
       # Updates a view in the database.
@@ -79,11 +82,13 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
+      # @param security_barrier If we should enable security_barrier
+      # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def update_view(name, sql_definition)
+      def update_view(name, sql_definition, security_barrier, security_invoker)
         drop_view(name)
-        create_view(name, sql_definition)
+        create_view(name, sql_definition, security_barrier, security_invoker)
       end
 
       # Replaces a view in the database using `CREATE OR REPLACE VIEW`.
@@ -105,10 +110,13 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
+      # @param security_barrier If we should enable security_barrier
+      # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def replace_view(name, sql_definition)
-        execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+      def replace_view(name, sql_definition, security_barrier, security_invoker)
+        with_statement = build_with_statement(security_barrier, security_invoker)
+        execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
       end
 
       # Drops the named view from the database
@@ -201,7 +209,7 @@ module Scenic
       # This is typically called from application code via {Scenic.database}.
       #
       # @param name The name of the materialized view to refresh.
-      # @param concurrently [Boolean] Whether the refreshs hould happen
+      # @param concurrently [Boolean] Whether the refresh should happen
       #   concurrently or not. A concurrent refresh allows the view to be
       #   refreshed without locking the view for select but requires that the
       #   table have at least one unique index that covers all rows. Attempts to
@@ -298,6 +306,18 @@ module Scenic
           connection,
           concurrently: concurrently
         )
+      end
+
+      def build_with_statement(security_barrier, security_invoker)
+        if security_invoker && security_barrier
+          return "WITH (security_barrier, security_invoker = true)"
+        elsif security_invoker
+          return "WITH (security_invoker = true)"
+        elsif security_barrier
+          return "WITH (security_barrier)"
+        end
+
+        return ""
       end
     end
   end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -63,7 +63,7 @@ module Scenic
       # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def create_view(name, sql_definition, security_barrier, security_invoker)
+      def create_view(name, sql_definition, security_barrier: false, security_invoker: false)
         with_statement = build_with_statement(security_barrier, security_invoker)
         execute "CREATE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
       end
@@ -86,9 +86,9 @@ module Scenic
       # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def update_view(name, sql_definition, security_barrier, security_invoker)
+      def update_view(name, sql_definition, security_barrier: false, security_invoker: false)
         drop_view(name)
-        create_view(name, sql_definition, security_barrier, security_invoker)
+        create_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
       end
 
       # Replaces a view in the database using `CREATE OR REPLACE VIEW`.
@@ -114,7 +114,7 @@ module Scenic
       # @param security_invoker If we should enable security_invoker
       #
       # @return [void]
-      def replace_view(name, sql_definition, security_barrier, security_invoker)
+      def replace_view(name, sql_definition, security_barrier: false, security_invoker: false)
         with_statement = build_with_statement(security_barrier, security_invoker)
         execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} #{with_statement} AS #{sql_definition};"
       end
@@ -317,7 +317,7 @@ module Scenic
           return "WITH (security_barrier)"
         end
 
-        return ""
+        ""
       end
     end
   end

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -99,6 +99,7 @@ module Scenic
               c.relname as viewname,
               pg_get_viewdef(c.oid) AS definition,
               c.relkind AS kind,
+              c.reloptions AS options,
               n.nspname AS namespace
             FROM pg_class c
               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -112,10 +113,29 @@ module Scenic
         end
 
         def to_scenic_view(result)
+          namespace, viewname, options = result.values_at("namespace", "viewname", "options")
+
+          if options.present?
+           security_invoker = options.include?("security_invoker=true")
+           security_barrier = options.include?("security_barrier=true")
+          end
+
+          options = {
+            security_invoker:,
+            security_barrier:
+          }
+
+          namespaced_viewname = if namespace != "public"
+            "#{pg_identifier(namespace)}.#{pg_identifier(viewname)}"
+          else
+            pg_identifier(viewname)
+          end
+
           Scenic::View.new(
-            name: namespaced_view_name(result),
+            name: namespaced_viewname,
             definition: result["definition"].strip,
-            materialized: result["kind"] == "m"
+            materialized: result["kind"] == "m",
+            options:
           )
         end
 

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -115,14 +115,17 @@ module Scenic
         def to_scenic_view(result)
           namespace, viewname, options = result.values_at("namespace", "viewname", "options")
 
+          security_invoker = false
+          security_barrier = false
+
           if options.present?
-           security_invoker = options.include?("security_invoker=true")
-           security_barrier = options.include?("security_barrier=true")
+            security_invoker = options.include?("security_invoker=true")
+            security_barrier = options.include?("security_barrier=true")
           end
 
           options = {
-            security_invoker:,
-            security_barrier:
+            security_invoker: security_invoker,
+            security_barrier: security_barrier
           }
 
           namespaced_viewname = if namespace != "public"

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -113,20 +113,9 @@ module Scenic
         end
 
         def to_scenic_view(result)
-          namespace, viewname, options = result.values_at("namespace", "viewname", "options")
+          namespace, viewname, reloptions = result.values_at("namespace", "viewname", "options")
 
-          security_invoker = false
-          security_barrier = false
-
-          if options.present?
-            security_invoker = options.include?("security_invoker=true")
-            security_barrier = options.include?("security_barrier=true")
-          end
-
-          options = {
-            security_invoker: security_invoker,
-            security_barrier: security_barrier
-          }
+          options = parse_view_options(reloptions)
 
           namespaced_viewname = if namespace != "public"
             "#{pg_identifier(namespace)}.#{pg_identifier(viewname)}"
@@ -138,8 +127,30 @@ module Scenic
             name: namespaced_viewname,
             definition: result["definition"].strip,
             materialized: result["kind"] == "m",
-            options:
+            options: options
           )
+        end
+
+        def parse_view_options(reloptions)
+          return {} if reloptions.blank?
+
+          options = {}
+
+          reloptions.scan(/(\w+)(?:=(\w+))?/).each do |key, value|
+            key_sym = key.to_sym
+
+            options[key_sym] = if value.nil?
+              true
+            elsif value == "true"
+              true
+            elsif value == "false"
+              false
+            else
+              value
+            end
+          end
+
+          options
         end
 
         def namespaced_view_name(result)

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -14,10 +14,10 @@ module Scenic
     # @option materialized [Boolean] :no_data (false) Set to true to create
     #   materialized view without running the associated query. You will need
     #   to perform a non-concurrent refresh to populate with data.
-    # @param security_barrier [Boolean] Set to true to enable the security barrier
-    #   option on the view. Defaults to false.
-    # @param security_invoker [Boolean] Set to true to enable the security invoker
-    #   option on the view. Defaults to false.
+    # @param with [Hash] View options to pass to the WITH clause
+    # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+    # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+    # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
     # @return The database response from executing the create statement.
     #
     # @example Create from `db/views/searches_v02.sql`
@@ -28,8 +28,10 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false,
-      security_barrier: false, security_invoker: false)
+    # @example Create with view options
+    #   create_view(:secure_users, version: 1, with: { security_invoker: true })
+    #
+    def create_view(name, version: nil, sql_definition: nil, materialized: false, with: {})
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -52,7 +54,7 @@ module Scenic
           no_data: options[:no_data]
         )
       else
-        Scenic.database.create_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
+        Scenic.database.create_view(name, sql_definition, with: with)
       end
     end
 
@@ -64,16 +66,12 @@ module Scenic
     #   `version` argument to {#create_view}.
     # @param materialized [Boolean] Set to true if dropping a meterialized view.
     #   defaults to false.
-    # @param security_barrier [Boolean] Set to true to enable the security barrier
-    #   option on the view. Defaults to false.
-    # @param security_invoker [Boolean] Set to true to enable the security invoker
-    #   option on the view. Defaults to false.
     # @return The database response from executing the drop statement.
     #
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false, security_barrier: false, security_invoker: false)
+    def drop_view(name, revert_to_version: nil, materialized: false)
       if materialized
         Scenic.database.drop_materialized_view(name)
       else
@@ -105,17 +103,17 @@ module Scenic
     #   The view is initially updated with a temporary name and atomically
     #   swapped once it is successfully created with data. Cannot be combined
     #   with the :no_data option.
-    # @param security_barrier [Boolean] Set to true to enable the security barrier
-    #   option on the view. Defaults to false.
-    # @param security_invoker [Boolean] Set to true to enable the security invoker
-    #   option on the view. Defaults to false.
+    # @param with [Hash] View options to pass to the WITH clause
+    # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+    # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+    # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
     # @return The database response from executing the create statement.
     #
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #   update_view :comments, version: 2, revert_to_version: 1, materialized: { side_by_side: true }
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false,
-      security_barrier: false, security_invoker: false)
+    #   update_view :secure_users, version: 2, with: { security_invoker: true }
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false, with: {})
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -153,7 +151,7 @@ module Scenic
           side_by_side: options[:side_by_side]
         )
       else
-        Scenic.database.update_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
+        Scenic.database.update_view(name, sql_definition, with: with)
       end
     end
 
@@ -168,17 +166,17 @@ module Scenic
     # @param version [Fixnum] The version number of the view.
     # @param revert_to_version [Fixnum] The version number to rollback to on
     #   `rake db rollback`
-    # @param security_barrier [Boolean] Set to true to enable the security barrier
-    #   option on the view. Defaults to false.
-    # @param security_invoker [Boolean] Set to true to enable the security invoker
-    #   option on the view. Defaults to false.
+    # @param with [Hash] View options to pass to the WITH clause
+    # @option with [Boolean] :security_barrier Prevents data leakage through query optimizer
+    # @option with [Boolean] :security_invoker Use invoker's permissions instead of owner's
+    # @option with [Symbol, String] :check_option (:local or :cascaded) for updatable views
     # @return The database response from executing the create statement.
     #
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
+    #   replace_view :secure_users, version: 2, with: { security_invoker: true }
     #
-    def replace_view(name, version: nil, revert_to_version: nil, materialized: false,
-      security_barrier: false, security_invoker: false)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false, with: {})
       if version.blank?
         raise ArgumentError, "version is required"
       end
@@ -189,7 +187,7 @@ module Scenic
 
       sql_definition = definition(name, version)
 
-      Scenic.database.replace_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
+      Scenic.database.replace_view(name, sql_definition, with: with)
     end
 
     private

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -52,7 +52,7 @@ module Scenic
           no_data: options[:no_data]
         )
       else
-        Scenic.database.create_view(name, sql_definition, security_barrier, security_invoker)
+        Scenic.database.create_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
       end
     end
 
@@ -153,7 +153,7 @@ module Scenic
           side_by_side: options[:side_by_side]
         )
       else
-        Scenic.database.update_view(name, sql_definition, security_barrier, security_invoker)
+        Scenic.database.update_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
       end
     end
 
@@ -189,7 +189,7 @@ module Scenic
 
       sql_definition = definition(name, version)
 
-      Scenic.database.replace_view(name, sql_definition, security_barrier, security_invoker)
+      Scenic.database.replace_view(name, sql_definition, security_barrier: security_barrier, security_invoker: security_invoker)
     end
 
     private

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -14,6 +14,10 @@ module Scenic
     # @option materialized [Boolean] :no_data (false) Set to true to create
     #   materialized view without running the associated query. You will need
     #   to perform a non-concurrent refresh to populate with data.
+    # @param security_barrier [Boolean] Set to true to enable the security barrier
+    #   option on the view. Defaults to false.
+    # @param security_invoker [Boolean] Set to true to enable the security invoker
+    #   option on the view. Defaults to false.
     # @return The database response from executing the create statement.
     #
     # @example Create from `db/views/searches_v02.sql`
@@ -24,7 +28,8 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false)
+    def create_view(name, version: nil, sql_definition: nil, materialized: false,
+      security_barrier: false, security_invoker: false)
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -47,7 +52,7 @@ module Scenic
           no_data: options[:no_data]
         )
       else
-        Scenic.database.create_view(name, sql_definition)
+        Scenic.database.create_view(name, sql_definition, security_barrier, security_invoker)
       end
     end
 
@@ -59,12 +64,16 @@ module Scenic
     #   `version` argument to {#create_view}.
     # @param materialized [Boolean] Set to true if dropping a meterialized view.
     #   defaults to false.
+    # @param security_barrier [Boolean] Set to true to enable the security barrier
+    #   option on the view. Defaults to false.
+    # @param security_invoker [Boolean] Set to true to enable the security invoker
+    #   option on the view. Defaults to false.
     # @return The database response from executing the drop statement.
     #
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    def drop_view(name, revert_to_version: nil, materialized: false, security_barrier: false, security_invoker: false)
       if materialized
         Scenic.database.drop_materialized_view(name)
       else
@@ -96,12 +105,17 @@ module Scenic
     #   The view is initially updated with a temporary name and atomically
     #   swapped once it is successfully created with data. Cannot be combined
     #   with the :no_data option.
+    # @param security_barrier [Boolean] Set to true to enable the security barrier
+    #   option on the view. Defaults to false.
+    # @param security_invoker [Boolean] Set to true to enable the security invoker
+    #   option on the view. Defaults to false.
     # @return The database response from executing the create statement.
     #
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #   update_view :comments, version: 2, revert_to_version: 1, materialized: { side_by_side: true }
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false,
+      security_barrier: false, security_invoker: false)
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -139,7 +153,7 @@ module Scenic
           side_by_side: options[:side_by_side]
         )
       else
-        Scenic.database.update_view(name, sql_definition)
+        Scenic.database.update_view(name, sql_definition, security_barrier, security_invoker)
       end
     end
 
@@ -154,12 +168,17 @@ module Scenic
     # @param version [Fixnum] The version number of the view.
     # @param revert_to_version [Fixnum] The version number to rollback to on
     #   `rake db rollback`
+    # @param security_barrier [Boolean] Set to true to enable the security barrier
+    #   option on the view. Defaults to false.
+    # @param security_invoker [Boolean] Set to true to enable the security invoker
+    #   option on the view. Defaults to false.
     # @return The database response from executing the create statement.
     #
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def replace_view(name, version: nil, revert_to_version: nil, materialized: false)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false,
+      security_barrier: false, security_invoker: false)
       if version.blank?
         raise ArgumentError, "version is required"
       end
@@ -170,7 +189,7 @@ module Scenic
 
       sql_definition = definition(name, version)
 
-      Scenic.database.replace_view(name, sql_definition)
+      Scenic.database.replace_view(name, sql_definition, security_barrier, security_invoker)
     end
 
     private

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -22,30 +22,38 @@ module Scenic
     # @return [Boolean]
     attr_reader :materialized
 
+    # Options definition for security_invoker and security_barrier
+    # @return Hash[Symbol, Boolean]
+    attr_reader :options
+
     # Returns a new instance of View.
     #
     # @param name [String] The name of the view.
     # @param definition [String] The SQL for the query that defines the view.
     # @param materialized [Boolean] `true` if the view is materialized.
-    def initialize(name:, definition:, materialized:)
+    def initialize(name:, definition:, materialized:, options:)
       @name = name
       @definition = definition
       @materialized = materialized
+      @options = options
     end
 
     # @api private
     def ==(other)
       name == other.name &&
         definition == other.definition &&
-        materialized == other.materialized
+        materialized == other.materialized &&
+        options == other.options
     end
 
     # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
+      security_barrier_option = options[:security_barrier] ? "security_barrier: true, " : ""
+      security_invoker_option = options[:security_invoker] ? "security_invoker: true, " : ""
 
       <<-DEFINITION
-  create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
+  create_view #{UnaffixedName.for(name).inspect}, #{security_barrier_option}#{security_invoker_option}#{materialized_option}sql_definition: <<-\SQL
     #{escaped_definition.indent(2)}
   SQL
       DEFINITION

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -22,8 +22,8 @@ module Scenic
     # @return [Boolean]
     attr_reader :materialized
 
-    # Options definition for security_invoker and security_barrier
-    # @return Hash[Symbol, Boolean]
+    # Options hash for view WITH clause options
+    # @return [Hash{Symbol => Object}]
     attr_reader :options
 
     # Returns a new instance of View.
@@ -49,11 +49,16 @@ module Scenic
     # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
-      security_barrier_option = options[:security_barrier] ? "security_barrier: true, " : ""
-      security_invoker_option = options[:security_invoker] ? "security_invoker: true, " : ""
+
+      with_option = if options.present? && options.any?
+        with_hash = options.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")
+        "with: { #{with_hash} }, "
+      else
+        ""
+      end
 
       <<-DEFINITION
-  create_view #{UnaffixedName.for(name).inspect}, #{security_barrier_option}#{security_invoker_option}#{materialized_option}sql_definition: <<-\SQL
+  create_view #{UnaffixedName.for(name).inspect}, #{with_option}#{materialized_option}sql_definition: <<-\SQL
     #{escaped_definition.indent(2)}
   SQL
       DEFINITION

--- a/spec/scenic/adapters/postgres/views_spec.rb
+++ b/spec/scenic/adapters/postgres/views_spec.rb
@@ -18,6 +18,55 @@ module Scenic
         expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
       end
 
+      it "returns scenic view objects with security_barrier option" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE VIEW secure_children WITH (security_barrier) AS SELECT text 'Elliot' AS name
+        SQL
+
+        views = Postgres::Views.new(connection).all
+        first = views.first
+
+        expect(views.size).to eq 1
+        expect(first.name).to eq "secure_children"
+        expect(first.materialized).to be false
+        expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
+        expect(first.options[:security_barrier]).to eq true
+      end
+
+      it "returns scenic view objects with security_invoker option" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE VIEW invoker_children WITH (security_invoker = true) AS SELECT text 'Elliot' AS name
+        SQL
+
+        views = Postgres::Views.new(connection).all
+        first = views.first
+
+        expect(views.size).to eq 1
+        expect(first.name).to eq "invoker_children"
+        expect(first.materialized).to be false
+        expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
+        expect(first.options[:security_invoker]).to eq true
+      end
+
+      it "returns scenic view objects with both security options" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE VIEW secure_invoker_children WITH (security_barrier, security_invoker = true) AS SELECT text 'Elliot' AS name
+        SQL
+
+        views = Postgres::Views.new(connection).all
+        first = views.first
+
+        expect(views.size).to eq 1
+        expect(first.name).to eq "secure_invoker_children"
+        expect(first.materialized).to be false
+        expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
+        expect(first.options[:security_barrier]).to eq true
+        expect(first.options[:security_invoker]).to eq true
+      end
+
       it "returns scenic view objects for materialized views" do
         connection = ActiveRecord::Base.connection
         connection.execute <<-SQL

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -15,7 +15,7 @@ module Scenic
         it "successfully creates a view with security_barrier" do
           adapter = Postgres.new
 
-          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_barrier: true)
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", with: {security_barrier: true})
 
           view = adapter.views.find { |v| v.name == "greetings" }
           expect(view.options[:security_barrier]).to eq(true)
@@ -24,7 +24,7 @@ module Scenic
         it "successfully creates a view with security_invoker" do
           adapter = Postgres.new
 
-          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_invoker: true)
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", with: {security_invoker: true})
 
           view = adapter.views.find { |v| v.name == "greetings" }
           expect(view.options[:security_invoker]).to eq(true)
@@ -33,7 +33,7 @@ module Scenic
         it "successfully creates a view with both security_barrier and security_invoker" do
           adapter = Postgres.new
 
-          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_barrier: true, security_invoker: true)
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", with: {security_barrier: true, security_invoker: true})
 
           view = adapter.views.find { |v| v.name == "greetings" }
           expect(view.options[:security_barrier]).to eq(true)
@@ -100,7 +100,7 @@ module Scenic
 
           adapter.create_view("greetings", "SELECT text 'hi' AS greeting")
 
-          adapter.replace_view("greetings", "SELECT text 'hello' AS greeting", security_barrier: true, security_invoker: true)
+          adapter.replace_view("greetings", "SELECT text 'hello' AS greeting", with: {security_barrier: true, security_invoker: true})
 
           view = adapter.views.find { |v| v.name == "greetings" }
           expect(view.definition).to eql "SELECT 'hello'::text AS greeting;"

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -11,6 +11,34 @@ module Scenic
 
           expect(adapter.views.map(&:name)).to include("greetings")
         end
+
+        it "successfully creates a view with security_barrier" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_barrier: true)
+
+          view = adapter.views.find { |v| v.name == "greetings" }
+          expect(view.options[:security_barrier]).to eq(true)
+        end
+
+        it "successfully creates a view with security_invoker" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_invoker: true)
+
+          view = adapter.views.find { |v| v.name == "greetings" }
+          expect(view.options[:security_invoker]).to eq(true)
+        end
+
+        it "successfully creates a view with both security_barrier and security_invoker" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting", security_barrier: true, security_invoker: true)
+
+          view = adapter.views.find { |v| v.name == "greetings" }
+          expect(view.options[:security_barrier]).to eq(true)
+          expect(view.options[:security_invoker]).to eq(true)
+        end
       end
 
       describe "#create_materialized_view" do
@@ -65,6 +93,19 @@ module Scenic
 
           view = adapter.views.first.definition
           expect(view).to eql "SELECT 'hello'::text AS greeting;"
+        end
+
+        it "successfully replaces a view with security options" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting")
+
+          adapter.replace_view("greetings", "SELECT text 'hello' AS greeting", security_barrier: true, security_invoker: true)
+
+          view = adapter.views.find { |v| v.name == "greetings" }
+          expect(view.definition).to eql "SELECT 'hello'::text AS greeting;"
+          expect(view.options[:security_barrier]).to eq(true)
+          expect(view.options[:security_invoker]).to eq(true)
         end
       end
 

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -22,7 +22,7 @@ module Scenic
       end
 
       it "creates a view from a text definition" do
-        sql_definition = "a defintion"
+        sql_definition = "a definition"
 
         connection.create_view(:views, sql_definition: sql_definition)
 
@@ -30,7 +30,7 @@ module Scenic
           .with(:views, sql_definition)
       end
 
-      it "creates version 1 of the view if neither version nor sql_defintion are provided" do
+      it "creates version 1 of the view if neither version nor sql_definition are provided" do
         version = 1
         definition_stub = instance_double("Definition", to_sql: "foo")
         allow(Definition).to receive(:new)
@@ -43,9 +43,9 @@ module Scenic
           .with(:views, definition_stub.to_sql)
       end
 
-      it "raises an error if both version and sql_defintion are provided" do
+      it "raises an error if both version and sql_definition are provided" do
         expect do
-          connection.create_view :foo, version: 1, sql_definition: "a defintion"
+          connection.create_view :foo, version: 1, sql_definition: "a definition"
         end.to raise_error ArgumentError
       end
     end
@@ -108,7 +108,7 @@ module Scenic
       end
 
       it "updates a view from a text definition" do
-        sql_definition = "a defintion"
+        sql_definition = "a definition"
 
         connection.update_view(:name, sql_definition: sql_definition)
 
@@ -160,19 +160,19 @@ module Scenic
           .with(:name, definition.to_sql, no_data: false, side_by_side: true)
       end
 
-      it "raises an error if not supplied a version or sql_defintion" do
+      it "raises an error if not supplied a version or sql_definition" do
         expect { connection.update_view :views }.to raise_error(
           ArgumentError,
           /sql_definition or version must be specified/
         )
       end
 
-      it "raises an error if both version and sql_defintion are provided" do
+      it "raises an error if both version and sql_definition are provided" do
         expect do
           connection.update_view(
             :views,
             version: 1,
-            sql_definition: "a defintion"
+            sql_definition: "a definition"
           )
         end.to raise_error ArgumentError, /cannot both be set/
       end

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -18,7 +18,7 @@ module Scenic
         connection.create_view :views, version: version
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql)
+          .with(:views, definition_stub.to_sql, security_barrier: false, security_invoker: false)
       end
 
       it "creates a view from a text definition" do
@@ -27,7 +27,7 @@ module Scenic
         connection.create_view(:views, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition)
+          .with(:views, sql_definition, security_barrier: false, security_invoker: false)
       end
 
       it "creates version 1 of the view if neither version nor sql_definition are provided" do
@@ -40,7 +40,34 @@ module Scenic
         connection.create_view :views
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql)
+          .with(:views, definition_stub.to_sql, security_barrier: false, security_invoker: false)
+      end
+
+      it "creates a view with security_barrier" do
+        sql_definition = "a definition"
+
+        connection.create_view(:views, sql_definition: sql_definition, security_barrier: true)
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition, hash_including(security_barrier: true))
+      end
+
+      it "creates a view with security_invoker" do
+        sql_definition = "a definition"
+
+        connection.create_view(:views, sql_definition: sql_definition, security_invoker: true)
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition, hash_including(security_invoker: true))
+      end
+
+      it "creates a view with both security options" do
+        sql_definition = "a definition"
+
+        connection.create_view(:views, sql_definition: sql_definition, security_barrier: true, security_invoker: true)
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition, security_barrier: true, security_invoker: true)
       end
 
       it "raises an error if both version and sql_definition are provided" do
@@ -104,7 +131,7 @@ module Scenic
         connection.update_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, definition.to_sql)
+          .with(:name, definition.to_sql, security_barrier: false, security_invoker: false)
       end
 
       it "updates a view from a text definition" do
@@ -113,7 +140,25 @@ module Scenic
         connection.update_view(:name, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, sql_definition)
+          .with(:name, sql_definition, security_barrier: false, security_invoker: false)
+      end
+
+      it "updates a view with security_barrier" do
+        sql_definition = "a definition"
+
+        connection.update_view(:name, sql_definition: sql_definition, security_barrier: true)
+
+        expect(Scenic.database).to have_received(:update_view)
+          .with(:name, sql_definition, hash_including(security_barrier: true))
+      end
+
+      it "updates a view with security_invoker" do
+        sql_definition = "a definition"
+
+        connection.update_view(:name, sql_definition: sql_definition, security_invoker: true)
+
+        expect(Scenic.database).to have_received(:update_view)
+          .with(:name, sql_definition, hash_including(security_invoker: true))
       end
 
       it "updates the materialized view in the database" do
@@ -218,7 +263,31 @@ module Scenic
         connection.replace_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:replace_view)
-          .with(:name, definition.to_sql)
+          .with(:name, definition.to_sql, security_barrier: false, security_invoker: false)
+      end
+
+      it "replaces a view with security_barrier" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3)
+          .and_return(definition)
+
+        connection.replace_view(:name, version: 3, security_barrier: true)
+
+        expect(Scenic.database).to have_received(:replace_view)
+          .with(:name, definition.to_sql, hash_including(security_barrier: true))
+      end
+
+      it "replaces a view with security_invoker" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3)
+          .and_return(definition)
+
+        connection.replace_view(:name, version: 3, security_invoker: true)
+
+        expect(Scenic.database).to have_received(:replace_view)
+          .with(:name, definition.to_sql, hash_including(security_invoker: true))
       end
 
       it "fails to replace the materialized view in the database" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -18,7 +18,7 @@ module Scenic
         connection.create_view :views, version: version
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql, security_barrier: false, security_invoker: false)
+          .with(:views, definition_stub.to_sql, with: {})
       end
 
       it "creates a view from a text definition" do
@@ -27,7 +27,7 @@ module Scenic
         connection.create_view(:views, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition, security_barrier: false, security_invoker: false)
+          .with(:views, sql_definition, with: {})
       end
 
       it "creates version 1 of the view if neither version nor sql_definition are provided" do
@@ -40,34 +40,34 @@ module Scenic
         connection.create_view :views
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, definition_stub.to_sql, security_barrier: false, security_invoker: false)
+          .with(:views, definition_stub.to_sql, with: {})
       end
 
       it "creates a view with security_barrier" do
         sql_definition = "a definition"
 
-        connection.create_view(:views, sql_definition: sql_definition, security_barrier: true)
+        connection.create_view(:views, sql_definition: sql_definition, with: {security_barrier: true})
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition, hash_including(security_barrier: true))
+          .with(:views, sql_definition, with: {security_barrier: true})
       end
 
       it "creates a view with security_invoker" do
         sql_definition = "a definition"
 
-        connection.create_view(:views, sql_definition: sql_definition, security_invoker: true)
+        connection.create_view(:views, sql_definition: sql_definition, with: {security_invoker: true})
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition, hash_including(security_invoker: true))
+          .with(:views, sql_definition, with: {security_invoker: true})
       end
 
       it "creates a view with both security options" do
         sql_definition = "a definition"
 
-        connection.create_view(:views, sql_definition: sql_definition, security_barrier: true, security_invoker: true)
+        connection.create_view(:views, sql_definition: sql_definition, with: {security_barrier: true, security_invoker: true})
 
         expect(Scenic.database).to have_received(:create_view)
-          .with(:views, sql_definition, security_barrier: true, security_invoker: true)
+          .with(:views, sql_definition, with: {security_barrier: true, security_invoker: true})
       end
 
       it "raises an error if both version and sql_definition are provided" do
@@ -131,7 +131,7 @@ module Scenic
         connection.update_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, definition.to_sql, security_barrier: false, security_invoker: false)
+          .with(:name, definition.to_sql, with: {})
       end
 
       it "updates a view from a text definition" do
@@ -140,25 +140,25 @@ module Scenic
         connection.update_view(:name, sql_definition: sql_definition)
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, sql_definition, security_barrier: false, security_invoker: false)
+          .with(:name, sql_definition, with: {})
       end
 
       it "updates a view with security_barrier" do
         sql_definition = "a definition"
 
-        connection.update_view(:name, sql_definition: sql_definition, security_barrier: true)
+        connection.update_view(:name, sql_definition: sql_definition, with: {security_barrier: true})
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, sql_definition, hash_including(security_barrier: true))
+          .with(:name, sql_definition, with: {security_barrier: true})
       end
 
       it "updates a view with security_invoker" do
         sql_definition = "a definition"
 
-        connection.update_view(:name, sql_definition: sql_definition, security_invoker: true)
+        connection.update_view(:name, sql_definition: sql_definition, with: {security_invoker: true})
 
         expect(Scenic.database).to have_received(:update_view)
-          .with(:name, sql_definition, hash_including(security_invoker: true))
+          .with(:name, sql_definition, with: {security_invoker: true})
       end
 
       it "updates the materialized view in the database" do
@@ -263,7 +263,7 @@ module Scenic
         connection.replace_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:replace_view)
-          .with(:name, definition.to_sql, security_barrier: false, security_invoker: false)
+          .with(:name, definition.to_sql, with: {})
       end
 
       it "replaces a view with security_barrier" do
@@ -272,10 +272,10 @@ module Scenic
           .with(:name, 3)
           .and_return(definition)
 
-        connection.replace_view(:name, version: 3, security_barrier: true)
+        connection.replace_view(:name, version: 3, with: {security_barrier: true})
 
         expect(Scenic.database).to have_received(:replace_view)
-          .with(:name, definition.to_sql, hash_including(security_barrier: true))
+          .with(:name, definition.to_sql, with: {security_barrier: true})
       end
 
       it "replaces a view with security_invoker" do
@@ -284,10 +284,10 @@ module Scenic
           .with(:name, 3)
           .and_return(definition)
 
-        connection.replace_view(:name, version: 3, security_invoker: true)
+        connection.replace_view(:name, version: 3, with: {security_invoker: true})
 
         expect(Scenic.database).to have_received(:replace_view)
-          .with(:name, definition.to_sql, hash_including(security_invoker: true))
+          .with(:name, definition.to_sql, with: {security_invoker: true})
       end
 
       it "fails to replace the materialized view in the database" do


### PR DESCRIPTION
Postgres accepts arguments in the form `WITH (<option>[ = <true|false>])`, so
rather than manually extending the various APIs to accept them individually
let's take a `with: {...}` argument that can take in arbitrary values.

The argument handling is:

- `false` or `null` values are discarded as the default behavior
- `true` values are passed as `<option> = true`
- other String or Symbol values are passed as `<option> = <value>`

This provides a more extensible API that can support any PostgreSQL view option
without requiring changes to Scenic's code, as evidence has shown that Derek and
I aren't super responsive maintainers. This should allow extensibility with new
Postgres (and other) features without requiring one of us to add support for
them.

A drawback and/or strength of this approach is that maintainers of Scenic
adapters such as MySQL or SQLite[^pronunciation] will have to deal with the
`with` hash individually, and that it may break migrations between databases. I
suspect that the latter is (a). unlikely to ever come up and (b). the least of the
worries of developers who undertake this.

- Add parse_view_options helper to generically parse PostgreSQL reloptions

[^pronunciation]: I just want to call out that "SQLite" is intended to be
pronounced as rhyming with meteorite and not with blight because I think that's
fun.

Conventional: Feat
Feat: Allow `with` argument to *_view to be passed to view DDL statements
Conventional: BREAKING CHANGE
Breaking: Users of the #433 fork will
          need to adjust their arguments slightly.
Closes: https://github.com/scenic-views/scenic/pull/433
Closes: https://github.com/scenic-views/scenic/issues/432