### PR TITLE
Respect pluralize_table_names option when creating views

### DIFF
--- a/lib/generators/scenic/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/create_view.erb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
-    create_view <%= formatted_plural_name %><%= create_view_options %>
+    create_view <%= formatted_name %><%= create_view_options %>
   end
 end

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -2,12 +2,12 @@ class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
   <%- method_name = replace_view? ? 'replace_view' : 'update_view' -%>
   <%- if materialized? -%>
-    <%= method_name %> <%= formatted_plural_name %>,
+    <%= method_name %> <%= formatted_name %>,
       version: <%= version %>,
       revert_to_version: <%= previous_version %>,
       materialized: <%= materialized_view_update_options %>
   <%- else -%>
-    <%= method_name %> <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
+    <%= method_name %> <%= formatted_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   <%- end -%>
   end
 end

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -12,9 +12,9 @@ module Scenic
       source_root File.expand_path("templates", __dir__)
 
       def create_views_directory
-        unless views_directory_path.exist?
-          empty_directory(views_directory_path)
-        end
+        return if views_directory_path.exist?
+
+        empty_directory(views_directory_path)
       end
 
       def create_view_definition
@@ -29,12 +29,12 @@ module Scenic
         if creating_new_view? || destroying_initial_view?
           migration_template(
             "db/migrate/create_view.erb",
-            "db/migrate/create_#{plural_file_name}.rb"
+            "db/migrate/create_#{canonical_file_name}.rb"
           )
         else
           migration_template(
             "db/migrate/update_view.erb",
-            "db/migrate/update_#{plural_file_name}_to_version_#{version}.rb"
+            "db/migrate/update_#{canonical_file_name}_to_version_#{version}.rb"
           )
         end
       end
@@ -57,9 +57,13 @@ module Scenic
 
         def migration_class_name
           if creating_new_view?
-            "Create#{class_name.tr(".", "").pluralize}"
+            name = class_name.tr(".", "")
+            name = name.pluralize if pluralize_table_names?
+            "Create#{name}"
           else
-            "Update#{class_name.pluralize}ToVersion#{version}"
+            name = class_name
+            name = name.pluralize if pluralize_table_names?
+            "Update#{name}ToVersion#{version}"
           end
         end
 
@@ -80,12 +84,16 @@ module Scenic
         super.tr(".", "_")
       end
 
+      def canonical_file_name
+        pluralize_table_names? ? plural_file_name : file_name
+      end
+
       def views_directory_path
         @views_directory_path ||= Rails.root.join("db", "views")
       end
 
       def version_regex
-        /\A#{plural_file_name}_v(?<version>\d+)\.sql\z/
+        /\A#{canonical_file_name}_v(?<version>\d+)\.sql\z/
       end
 
       def creating_new_view?
@@ -93,22 +101,23 @@ module Scenic
       end
 
       def definition
-        Scenic::Definition.new(plural_file_name, version)
+        Scenic::Definition.new(canonical_file_name, version)
       end
 
       def previous_definition
-        Scenic::Definition.new(plural_file_name, previous_version)
+        Scenic::Definition.new(canonical_file_name, previous_version)
       end
 
       def destroying?
         behavior == :revoke
       end
 
-      def formatted_plural_name
-        if plural_name.include?(".")
-          "\"#{plural_name}\""
+      def formatted_name
+        name = pluralize_table_names? ? plural_name : singular_name
+        if name.include?(".")
+          "\"#{name}\""
         else
-          ":#{plural_name}"
+          ":#{name}"
         end
       end
 

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -75,12 +75,39 @@ describe Scenic::Generators::ViewGenerator, :generator do
     end
   end
 
+  context "when pluralize_table_names set to 'false'" do
+    around do |example|
+      with_singular_table_names(&example)
+    end
+
+    it "creates a singularized view definition and migration file" do
+      view_definition = file("db/views/search_v01.sql")
+      run_generator ["search"]
+      expect(view_definition).to exist
+      migration = migration_file("db/migrate/create_search.rb")
+      expect(migration).to contain(/class CreateSearch/)
+      expect(migration).to contain(/create_view :search/)
+    end
+
+    it "updates an existing singularized view" do
+      with_view_definition("search", 1, "hello") do
+        migration = file("db/migrate/update_search_to_version_2.rb")
+        view_definition = file("db/views/search_v02.sql")
+        allow(Dir).to receive(:entries).and_return(["search_v01.sql"])
+
+        run_generator ["search"]
+
+        expect(migration).to be_a_migration
+        expect(view_definition).to exist
+      end
+    end
+  end
+
   context "for views created in a schema other than 'public'" do
     it "creates a view definition" do
       view_definition = file("db/views/non_public_searches_v01.sql")
 
       run_generator ["non_public.search"]
-
       expect(view_definition).to exist
     end
 

--- a/spec/support/rails_configuration_helpers.rb
+++ b/spec/support/rails_configuration_helpers.rb
@@ -7,4 +7,11 @@ module RailsConfigurationHelpers
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
   end
+
+  def with_singular_table_names
+    ActiveRecord::Base.pluralize_table_names = false
+    yield
+  ensure
+    ActiveRecord::Base.pluralize_table_names = true
+  end
 end


### PR DESCRIPTION
References #312

As a preamble, I have followed all the steps in `CONTRIBUTING.md` and have attempted to change the smallest number of lines of code possible.

This PR allows Scenic to respect the `pluralize_table_names` option when creating views. Formerly, if `pluralize_table_names` was set to `false`, Scenic would still create a pluralized view and migration file, e.g.:

```rb
# config/application.rb

Rails.application.configure do
  # snip
  config.active_record.pluralize_table_names = false
end
```

The generator command:

```shell
./bin/rails g scenic:view search
``` 

Outputs:

- `db/migrate/TIMESTAMP_create_searches.rb` 
- `db/views/searches_v01.sql`.

Now, with the aforementioned config, this is our output:

- `db/migrate/TIMESTAMP_create_search.rb` 
- `db/views/search_v01.sql`.

Updating migrations works as well: `./bin/rails generate scenic:view search` a second time will output:

- `db/migrate/TIMESTAMP_update_search_to_version_2.rb` 
- `db/views/search_v02.sql`.

