### PR TITLE
bugfix: remove anonymous block forwarding in order to satisfy gemspec compatiblity

### DIFF
--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -1,3 +1,5 @@
+require "tsort"
+
 module Scenic
   module Adapters
     class Postgres
@@ -87,8 +89,8 @@ module Scenic
           include TSort
 
           alias_method :tsort_each_node, :each_key
-          def tsort_each_child(node, &)
-            fetch(node).each(&)
+          def tsort_each_child(node, &block)
+            fetch(node).each(&block)
           end
         end
         private_constant :TSortableHash


### PR DESCRIPTION
 * also adds an explicit require for tsort in the postgres view adapter for compatibility with non-standard installations of the gem that may depend on railties load order

### Extra Detail

The gemspec specifies ruby >= 2.3, but anonymous block forwarding is a Ruby 3.1+ feature.  In order to maintain ruby compatibility I updated the code - rather than update the gemspec, which may block some others using this gem that have not had the chance to upgrade their ruby (including myself) yet but may want to stay up to date with scenic.

There were also some...quirkiness...with the load order with my particular rails setup which prevented the gem from loading correctly, but adding the explict require cleared it up.