### PR TITLE
Add a column_defaults option for views

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ def change
 end
 ```
 
+## Can my updatable views have column defaults?
+
+A view column can carry a `DEFAULT`, which is what lets an updatable view be
+inserted into without naming every column. They aren't included in the view
+definition, but they can be set with ALTER VIEW. Scenic accepts a
+`column_defaults` option mapping column names to SQL expressions:
+
+```ruby
+create_view "clients", column_defaults: {"position" => "1"}, sql_definition: <<-SQL
+  ...
+SQL
+```
+
+Passing nil as a value removes that column's default.
+
+You can also use this option on `replace_view`, `update_view`, and `drop_view`.
+
 ## FAQs
 
 ### Why do I get an error when querying a view-backed model with `find`, `last`, or `first`?

--- a/lib/scenic/adapters/errors.rb
+++ b/lib/scenic/adapters/errors.rb
@@ -1,0 +1,12 @@
+module Scenic
+  module Adapters
+    # Raised when view column defaults are used with an adapter that does not
+    # support them. An adapter should return true from
+    # `supports_column_defaults?` when supported.
+    class ColumnDefaultsNotSupportedError < StandardError
+      def initialize(adapter = Scenic.database)
+        super("#{adapter.class} does not support view column defaults")
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -1,4 +1,5 @@
 require_relative "postgres/connection"
+require_relative "errors"
 require_relative "postgres/errors"
 require_relative "postgres/index_reapplication"
 require_relative "postgres/indexes"
@@ -53,16 +54,30 @@ module Scenic
         Views.new(connection).all
       end
 
+      # True if this adapter supports view column defaults.
+      #
+      # Postgres does, via `ALTER VIEW ... ALTER COLUMN ... SET DEFAULT`.
+      #
+      # @return [Boolean]
+      def supports_column_defaults?
+        true
+      end
+
       # Creates a view in the database.
       #
       # This is typically called in a migration via {Statements#create_view}.
       #
       # @param name The name of the view to create
       # @param sql_definition The SQL schema for the view.
+      # @param column_defaults [Hash] Default values for the view's columns, as
+      #   column name => SQL expression. `CREATE VIEW` cannot express these, so
+      #   they are applied afterwards with `ALTER VIEW`. A nil value removes
+      #   the column's default.
       #
       # @return [void]
-      def create_view(name, sql_definition)
+      def create_view(name, sql_definition, column_defaults: {})
         execute "CREATE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+        set_column_defaults(name, column_defaults)
       end
 
       # Updates a view in the database.
@@ -79,11 +94,15 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
+      # @param column_defaults [Hash] Default values for the view's columns, as
+      #   column name => SQL expression. `CREATE VIEW` cannot express these, so
+      #   they are applied afterwards with `ALTER VIEW`. A nil value removes
+      #   the column's default.
       #
       # @return [void]
-      def update_view(name, sql_definition)
+      def update_view(name, sql_definition, column_defaults: {})
         drop_view(name)
-        create_view(name, sql_definition)
+        create_view(name, sql_definition, column_defaults: column_defaults)
       end
 
       # Replaces a view in the database using `CREATE OR REPLACE VIEW`.
@@ -105,10 +124,15 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
+      # @param column_defaults [Hash] Default values for the view's columns, as
+      #   column name => SQL expression. `CREATE VIEW` cannot express these, so
+      #   they are applied afterwards with `ALTER VIEW`. A nil value removes
+      #   the column's default.
       #
       # @return [void]
-      def replace_view(name, sql_definition)
+      def replace_view(name, sql_definition, column_defaults: {})
         execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+        set_column_defaults(name, column_defaults)
       end
 
       # Drops the named view from the database
@@ -277,7 +301,20 @@ module Scenic
       private
 
       attr_reader :connectable
-      delegate :execute, :quote_table_name, to: :connection
+      delegate :execute, :quote_table_name, :quote_column_name, to: :connection
+
+      # A view column can carry a DEFAULT, which is what lets an updatable view
+      # be inserted into without naming every column. CREATE VIEW cannot set
+      # one, so each is applied as its own ALTER VIEW.
+      #
+      # Only the named columns are touched; defaults on other columns are left
+      # as they are. A nil default removes the column's default.
+      def set_column_defaults(name, column_defaults)
+        column_defaults.each do |column, default|
+          execute "ALTER VIEW #{quote_table_name(name)} " \
+                  "ALTER COLUMN #{quote_column_name(column)} SET DEFAULT #{default || "NULL"};"
+        end
+      end
 
       def raise_unless_materialized_views_supported
         unless connection.supports_materialized_views?

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -16,7 +16,10 @@ module Scenic
         #
         # @return [Array<Scenic::View>]
         def all
-          scenic_views = views_from_postgres.map(&method(:to_scenic_view))
+          defaults = column_defaults_from_postgres
+          scenic_views = views_from_postgres.map do |result|
+            to_scenic_view(result, defaults)
+          end
           sort(scenic_views)
         end
 
@@ -111,12 +114,42 @@ module Scenic
           SQL
         end
 
-        def to_scenic_view(result)
+        def to_scenic_view(result, defaults)
+          namespace, viewname = result.values_at("namespace", "viewname")
+
           Scenic::View.new(
             name: namespaced_view_name(result),
             definition: result["definition"].strip,
-            materialized: result["kind"] == "m"
+            materialized: result["kind"] == "m",
+            column_defaults: defaults.fetch([namespace, viewname], {})
           )
+        end
+
+        # A view column can carry a DEFAULT, which CREATE VIEW cannot express,
+        # so it is fetched separately and dumped as its own statement. Keyed by
+        # [namespace, viewname] to match views_from_postgres. Materialized views
+        # cannot have column defaults, so only plain views turn up here.
+        def column_defaults_from_postgres
+          connection.execute(<<-SQL).each_with_object({}) do |row, defaults|
+            SELECT
+              n.nspname AS namespace,
+              c.relname AS viewname,
+              a.attname AS column_name,
+              pg_get_expr(d.adbin, d.adrelid) AS default_value
+            FROM pg_attrdef d
+              JOIN pg_class c ON c.oid = d.adrelid
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.adnum
+            WHERE
+              c.relkind = 'v'
+              AND NOT a.attisdropped
+              AND n.nspname = ANY (current_schemas(false))
+            ORDER BY a.attnum
+          SQL
+            key = row.values_at("namespace", "viewname")
+            defaults[key] ||= {}
+            defaults[key][row["column_name"]] = row["default_value"]
+          end
         end
 
         def namespaced_view_name(result)

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -14,6 +14,15 @@ module Scenic
     # @option materialized [Boolean] :no_data (false) Set to true to create
     #   materialized view without running the associated query. You will need
     #   to perform a non-concurrent refresh to populate with data.
+    # @param column_defaults [Hash] Default values for the view's columns, as
+    #   column name => SQL expression. A view column can carry a DEFAULT, which
+    #   is what lets an updatable view be inserted into without naming every
+    #   column. `CREATE VIEW` cannot express one, so these are applied
+    #   afterwards. Values are SQL, not Ruby: they are used verbatim, the same
+    #   way `sql_definition` is. A nil value removes the column's default.
+    #   Materialized views cannot have column defaults.
+    # @raise [Adapters::ColumnDefaultsNotSupportedError] if column defaults are
+    #   given and the configured adapter does not support them.
     # @return The database response from executing the create statement.
     #
     # @example Create from `db/views/searches_v02.sql`
@@ -24,7 +33,13 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false)
+    # @example Create an updatable view whose columns have defaults
+    #   create_view(:active_users, version: 1, column_defaults: {
+    #     active: "true",
+    #     status: "'pending'::text"
+    #   })
+    #
+    def create_view(name, version: nil, sql_definition: nil, materialized: false, column_defaults: {})
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -39,6 +54,8 @@ module Scenic
       sql_definition ||= definition(name, version)
 
       if materialized
+        raise_if_column_defaults_on_materialized_view(column_defaults)
+
         options = materialized_options(materialized)
 
         Scenic.database.create_materialized_view(
@@ -47,7 +64,7 @@ module Scenic
           no_data: options[:no_data]
         )
       else
-        Scenic.database.create_view(name, sql_definition)
+        Scenic.database.create_view(name, sql_definition, **column_defaults_option(column_defaults))
       end
     end
 
@@ -59,12 +76,21 @@ module Scenic
     #   `version` argument to {#create_view}.
     # @param materialized [Boolean] Set to true if dropping a meterialized view.
     #   defaults to false.
+    # @param column_defaults [Hash] Used, like `revert_to_version`, only to
+    #   reverse the `drop_view` command: the defaults are passed to
+    #   {#create_view} on `rake db:rollback`, so the view comes back with them.
+    #   Ignored when dropping.
     # @return The database response from executing the drop statement.
     #
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    # @example Drop an updatable view, restoring its column defaults on rollback
+    #   drop_view(:active_users, revert_to_version: 3, column_defaults: {
+    #     status: "'pending'::text"
+    #   })
+    #
+    def drop_view(name, revert_to_version: nil, materialized: false, column_defaults: {})
       if materialized
         Scenic.database.drop_materialized_view(name)
       else
@@ -96,12 +122,16 @@ module Scenic
     #   The view is initially updated with a temporary name and atomically
     #   swapped once it is successfully created with data. Cannot be combined
     #   with the :no_data option.
+    # @param column_defaults [Hash] Default values for the view's columns, as
+    #   column name => SQL expression. The view is dropped and recreated, which
+    #   discards any defaults it had, so pass them again here to keep them. See
+    #   {#create_view}.
     # @return The database response from executing the create statement.
     #
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #   update_view :comments, version: 2, revert_to_version: 1, materialized: { side_by_side: true }
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false, column_defaults: {})
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -119,6 +149,8 @@ module Scenic
       sql_definition ||= definition(name, version)
 
       if materialized
+        raise_if_column_defaults_on_materialized_view(column_defaults)
+
         options = materialized_options(materialized)
 
         if options[:no_data] && options[:side_by_side]
@@ -139,7 +171,7 @@ module Scenic
           side_by_side: options[:side_by_side]
         )
       else
-        Scenic.database.update_view(name, sql_definition)
+        Scenic.database.update_view(name, sql_definition, **column_defaults_option(column_defaults))
       end
     end
 
@@ -154,12 +186,16 @@ module Scenic
     # @param version [Fixnum] The version number of the view.
     # @param revert_to_version [Fixnum] The version number to rollback to on
     #   `rake db rollback`
+    # @param column_defaults [Hash] Default values for the view's columns, as
+    #   column name => SQL expression. See {#create_view}. `CREATE OR REPLACE
+    #   VIEW` keeps the defaults the view already has; the ones given here are
+    #   applied on top, and a nil value removes one.
     # @return The database response from executing the create statement.
     #
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def replace_view(name, version: nil, revert_to_version: nil, materialized: false)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false, column_defaults: {})
       if version.blank?
         raise ArgumentError, "version is required"
       end
@@ -170,13 +206,43 @@ module Scenic
 
       sql_definition = definition(name, version)
 
-      Scenic.database.replace_view(name, sql_definition)
+      Scenic.database.replace_view(name, sql_definition, **column_defaults_option(column_defaults))
     end
 
     private
 
     def definition(name, version)
       Scenic::Definition.new(name, version).to_sql
+    end
+
+    # Passed through only when the caller actually asked for defaults, so that
+    # adapters predating this option keep receiving the arguments they always
+    # did.
+    def column_defaults_option(column_defaults)
+      if column_defaults.present?
+        raise_unless_column_defaults_supported
+        {column_defaults: column_defaults}
+      else
+        {}
+      end
+    end
+
+    # An adapter advertises support by defining supports_column_defaults?. One
+    # written before the option existed does not, and would otherwise fail with
+    # an unhelpful "unknown keyword: :column_defaults".
+    def raise_unless_column_defaults_supported
+      adapter = Scenic.database
+
+      unless adapter.respond_to?(:supports_column_defaults?) &&
+          adapter.supports_column_defaults?
+        raise Adapters::ColumnDefaultsNotSupportedError.new(adapter)
+      end
+    end
+
+    def raise_if_column_defaults_on_materialized_view(column_defaults)
+      if column_defaults.present?
+        raise ArgumentError, "Materialized views cannot have column defaults"
+      end
     end
 
     def materialized_options(materialized)

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -22,30 +22,52 @@ module Scenic
     # @return [Boolean]
     attr_reader :materialized
 
+    # The default values defined on the view's columns, keyed by column name.
+    #
+    # A view column can carry a DEFAULT, which is what lets an updatable view be
+    # inserted into without naming every column. The database stores it on the
+    # view rather than in the view's query, so `CREATE VIEW` cannot express it
+    # and it has to be dumped separately from the definition.
+    #
+    # @return [Hash<String, String>] column name => default expression
+    #
+    # @example
+    #   { "status" => "'pending'::text" }
+    attr_reader :column_defaults
+
     # Returns a new instance of View.
     #
     # @param name [String] The name of the view.
     # @param definition [String] The SQL for the query that defines the view.
     # @param materialized [Boolean] `true` if the view is materialized.
-    def initialize(name:, definition:, materialized:)
+    # @param column_defaults [Hash<String, String>] The default values defined
+    #   on the view's columns, as column name => default expression.
+    def initialize(name:, definition:, materialized:, column_defaults: {})
       @name = name
       @definition = definition
       @materialized = materialized
+      @column_defaults = column_defaults
     end
 
     # @api private
     def ==(other)
       name == other.name &&
         definition == other.definition &&
-        materialized == other.materialized
+        materialized == other.materialized &&
+        column_defaults == other.column_defaults
     end
 
     # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
+      column_defaults_option = if column_defaults.any?
+        "column_defaults: #{column_defaults.inspect}, "
+      else
+        ""
+      end
 
       <<-DEFINITION
-  create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
+  create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}#{column_defaults_option}sql_definition: <<-\SQL
     #{escaped_definition.indent(2)}
   SQL
       DEFINITION

--- a/spec/scenic/adapters/postgres/views_spec.rb
+++ b/spec/scenic/adapters/postgres/views_spec.rb
@@ -18,6 +18,31 @@ module Scenic
         expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
       end
 
+      it "returns the column defaults defined on a view" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE VIEW children AS SELECT text 'Elliot' AS name, 1 AS age
+        SQL
+        connection.execute <<-SQL
+          ALTER VIEW children ALTER COLUMN age SET DEFAULT 7
+        SQL
+
+        views = Postgres::Views.new(connection).all
+
+        expect(views.first.column_defaults).to eq("age" => "7")
+      end
+
+      it "returns no column defaults for a view that has none" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE VIEW children AS SELECT text 'Elliot' AS name
+        SQL
+
+        views = Postgres::Views.new(connection).all
+
+        expect(views.first.column_defaults).to eq({})
+      end
+
       it "returns scenic view objects for materialized views" do
         connection = ActiveRecord::Base.connection
         connection.execute <<-SQL

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -3,6 +3,12 @@ require "spec_helper"
 module Scenic
   module Adapters
     describe Postgres, :db do
+      describe "#supports_column_defaults?" do
+        it "is true" do
+          expect(Postgres.new.supports_column_defaults?).to be true
+        end
+      end
+
       describe "#create_view" do
         it "successfully creates a view" do
           adapter = Postgres.new
@@ -10,6 +16,37 @@ module Scenic
           adapter.create_view("greetings", "SELECT text 'hi' AS greeting")
 
           expect(adapter.views.map(&:name)).to include("greetings")
+        end
+
+        it "applies column defaults" do
+          adapter = Postgres.new
+
+          adapter.create_view(
+            "greetings",
+            "SELECT text 'hi' AS greeting",
+            column_defaults: {greeting: "'hello'::text"}
+          )
+
+          expect(column_default(:greetings, :greeting)).to eq "'hello'::text"
+        end
+      end
+
+      describe "#replace_view" do
+        it "removes a column default when given nil" do
+          adapter = Postgres.new
+          adapter.create_view(
+            "greetings",
+            "SELECT text 'hi' AS greeting",
+            column_defaults: {greeting: "'hello'::text"}
+          )
+
+          adapter.replace_view(
+            "greetings",
+            "SELECT text 'hi' AS greeting",
+            column_defaults: {greeting: nil}
+          )
+
+          expect(column_default(:greetings, :greeting)).to be_nil
         end
       end
 

--- a/spec/scenic/command_recorder_spec.rb
+++ b/spec/scenic/command_recorder_spec.rb
@@ -20,6 +20,18 @@ describe Scenic::CommandRecorder do
       expect(recorder.commands).to eq [[:drop_view, [:greetings]]]
     end
 
+    it "passes column defaults through to drop_view so they survive a revert" do
+      column_defaults = {salutation: "'hi'::text"}
+
+      recorder.revert do
+        recorder.create_view :greetings, column_defaults: column_defaults
+      end
+
+      expect(recorder.commands).to eq [
+        [:drop_view, [:greetings, column_defaults: column_defaults]]
+      ]
+    end
+
     it "reverts materialized views appropriately" do
       recorder.revert { recorder.create_view :greetings, materialized: true }
 
@@ -39,6 +51,16 @@ describe Scenic::CommandRecorder do
     it "reverts to create_view with specified revert_to_version" do
       args = [:users, {revert_to_version: 3}]
       revert_args = [:users, {version: 3}]
+
+      recorder.revert { recorder.drop_view(*args) }
+
+      expect(recorder.commands).to eq [[:create_view, revert_args]]
+    end
+
+    it "reverts to create_view with the column defaults it was given" do
+      column_defaults = {status: "'pending'::text"}
+      args = [:users, {revert_to_version: 3, column_defaults: column_defaults}]
+      revert_args = [:users, {column_defaults: column_defaults, version: 3}]
 
       recorder.revert { recorder.drop_view(*args) }
 

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -26,6 +26,30 @@ describe Scenic::SchemaDumper, :db do
     expect(Search.first.haystack).to eq "needle"
   end
 
+  it "dumps the column defaults defined on a view" do
+    view_definition = "SELECT 'needle'::text AS haystack"
+    Search.connection.create_view :searches, sql_definition: view_definition
+    Search.connection.execute <<-SQL
+      ALTER VIEW searches ALTER COLUMN haystack SET DEFAULT 'default needle'
+    SQL
+    stream = StringIO.new
+
+    dump_schema(stream)
+
+    output = stream.string
+
+    column_defaults = {"haystack" => "'default needle'::text"}
+    expect(output).to include(
+      %(create_view "searches", column_defaults: #{column_defaults.inspect}, sql_definition:)
+    )
+
+    Search.connection.drop_view :searches
+
+    silence_stream($stdout) { eval(output) } # standard:disable Security/Eval
+
+    expect(column_default(:searches, :haystack)).to eq "'default needle'::text"
+  end
+
   it "accurately dumps create view statements with a regular expression" do
     view_definition = "SELECT 'needle'::text AS haystack WHERE 'a2z' ~ '\\d+'"
     Search.connection.create_view :searches, sql_definition: view_definition

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -30,6 +30,84 @@ module Scenic
           .with(:views, sql_definition)
       end
 
+      it "passes column defaults to the adapter" do
+        sql_definition = "a definition"
+        column_defaults = {status: "'pending'::text"}
+
+        connection.create_view(
+          :views,
+          sql_definition: sql_definition,
+          column_defaults: column_defaults
+        )
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition, column_defaults: column_defaults)
+      end
+
+      it "does not pass column defaults to the adapter when none are given" do
+        sql_definition = "a definition"
+
+        connection.create_view(:views, sql_definition: sql_definition)
+
+        expect(Scenic.database).to have_received(:create_view)
+          .with(:views, sql_definition)
+      end
+
+      it "raises when the adapter has no column default support" do
+        legacy_adapter = Class.new {
+          def create_view(name, sql_definition)
+          end
+        }.new
+        allow(Scenic).to receive(:database).and_return(legacy_adapter)
+
+        expect {
+          connection.create_view(
+            :views,
+            sql_definition: "a definition",
+            column_defaults: {status: "'pending'::text"}
+          )
+        }.to raise_error Scenic::Adapters::ColumnDefaultsNotSupportedError
+      end
+
+      it "raises when the adapter reports no column default support" do
+        adapter = instance_double(
+          "Scenic::Adapters::Postgres",
+          supports_column_defaults?: false
+        ).as_null_object
+        allow(Scenic).to receive(:database).and_return(adapter)
+
+        expect {
+          connection.create_view(
+            :views,
+            sql_definition: "a definition",
+            column_defaults: {status: "'pending'::text"}
+          )
+        }.to raise_error Scenic::Adapters::ColumnDefaultsNotSupportedError
+      end
+
+      it "does not consult the adapter when no column defaults are given" do
+        legacy_adapter = Class.new {
+          def create_view(name, sql_definition)
+          end
+        }.new
+        allow(Scenic).to receive(:database).and_return(legacy_adapter)
+
+        expect {
+          connection.create_view(:views, sql_definition: "a definition")
+        }.not_to raise_error
+      end
+
+      it "raises when column defaults are given for a materialized view" do
+        expect {
+          connection.create_view(
+            :views,
+            sql_definition: "a definition",
+            materialized: true,
+            column_defaults: {status: "'pending'::text"}
+          )
+        }.to raise_error ArgumentError, /materialized views cannot have column defaults/i
+      end
+
       it "creates version 1 of the view if neither version nor sql_defintion are provided" do
         version = 1
         definition_stub = instance_double("Definition", to_sql: "foo")
@@ -81,6 +159,14 @@ module Scenic
     describe "drop_view" do
       it "removes a view from the database" do
         connection.drop_view :name
+
+        expect(Scenic.database).to have_received(:drop_view).with(:name)
+      end
+
+      # column_defaults is carried for the sake of reversing the command, the
+      # same way revert_to_version is, and means nothing to the drop itself.
+      it "ignores column defaults when dropping" do
+        connection.drop_view :name, column_defaults: {status: "'pending'::text"}
 
         expect(Scenic.database).to have_received(:drop_view).with(:name)
       end

--- a/spec/support/database_schema_helpers.rb
+++ b/spec/support/database_schema_helpers.rb
@@ -20,6 +20,16 @@ module DatabaseSchemaHelpers
     ar_connection.add_index(view, columns, name: name)
   end
 
+  def column_default(view_name, column_name)
+    ar_connection.select_value(<<~SQL)
+      SELECT pg_get_expr(d.adbin, d.adrelid)
+      FROM pg_attrdef d
+        JOIN pg_class c ON c.oid = d.adrelid
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.adnum
+      WHERE c.relname = '#{view_name}' AND a.attname = '#{column_name}'
+    SQL
+  end
+
   def indexes_for(view_name)
     Scenic::Adapters::Postgres::Indexes
       .new(connection: ar_connection)


### PR DESCRIPTION
In Postgres, view columns can have a default, so that when you insert into an updatable view you don't have to specify that value. You can't include them in the view definition, but you can use ALTER VIEW to add them later.

This commit adds support for a column_defaults option in create_view, replace_view, update_view, and drop_view (so that it is invertible). This is included when dumping schema.rb. I takes a hash mapping column names to SQL expressions (as strings). Passing a nil value removes the default.

Materialized views cannot have column defaults, so passing them alongside materialized raises an ArgumentError.

Non-Postgres adapters by default raise a ColumnDefaultsNotSupportedError if given this option, unless they return true from `supports_column_defaults?`.